### PR TITLE
feature__cond-class

### DIFF
--- a/AraEvent/AraEventConditioner.cxx
+++ b/AraEvent/AraEventConditioner.cxx
@@ -1,0 +1,66 @@
+//////////////////////////////////////////////////////////////////////////////
+/////  AraEventConditioner.h        Conditioner                         /////
+/////                                                                    /////
+/////  Description:                                                      /////
+/////     The Ara class for conditioningevents                           /////
+/////  Author: Brian Clark (clark.2668@osu.edu)                          /////
+//////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include <fstream>
+#include <cstring>
+#include <cstdlib>
+
+#include "UsefulAtriStationEvent.h"
+#include "AraEventConditioner.h"
+#include "AraGeomTool.h"
+
+#include "TGraph.h"
+
+ClassImp(AraEventConditioner);
+
+AraEventConditioner * AraEventConditioner::fgInstance=0;
+
+AraEventConditioner::AraEventConditioner()
+{
+  //nothing right now
+}
+
+AraEventConditioner::~AraEventConditioner()
+{
+  //nothing right now
+}
+
+AraEventConditioner*  AraEventConditioner::Instance()
+{
+  if(fgInstance)
+    return fgInstance;
+
+  fgInstance = new AraEventConditioner();
+  return fgInstance;
+}
+
+void AraEventConditioner::conditionEvent(UsefulAtriStationEvent *theEvent)
+{
+
+  AraStationId_t thisStationId = theEvent->stationId;
+
+  if(theEvent->stationId==ARA_STATION3){
+    AraEventConditioner::invertA3Chans(theEvent);
+  }
+  // theEvent->fIsConditioned = true; //mark the event as conditioned
+  //now we're done
+}
+
+
+//! Inverts channels 0, 4, and 8 on A3
+/*!
+  \param ev the useful atri event pointer
+  \return void
+*/
+void AraEventConditioner::invertA3Chans(UsefulAtriStationEvent *theEvent){
+  int chan;
+  
+  chan=0;
+
+}

--- a/AraEvent/AraEventConditioner.cxx
+++ b/AraEvent/AraEventConditioner.cxx
@@ -48,7 +48,7 @@ void AraEventConditioner::conditionEvent(UsefulAtriStationEvent *theEvent)
   if(theEvent->stationId==ARA_STATION3){
     AraEventConditioner::invertA3Chans(theEvent);
   }
-  // theEvent->fIsConditioned = true; //mark the event as conditioned
+  theEvent->fIsConditioned = true; //mark the event as conditioned
   //now we're done
 }
 

--- a/AraEvent/AraEventConditioner.cxx
+++ b/AraEvent/AraEventConditioner.cxx
@@ -80,6 +80,6 @@ void AraEventConditioner::invertA3Chans(UsefulAtriStationEvent *theEvent){
     //record the inversion
     std::stringstream ss;
     ss<<"invert_ch"<<rf_chan;
-    theEvent->fCondtioningList.push_back(ss.str());
+    theEvent->fConditioningList.push_back(ss.str());
   }
 }

--- a/AraEvent/AraEventConditioner.cxx
+++ b/AraEvent/AraEventConditioner.cxx
@@ -15,6 +15,7 @@
 #include "UsefulAtriStationEvent.h"
 #include "AraEventConditioner.h"
 #include "AraGeomTool.h"
+#include "araSoft.h"
 
 #include "TGraph.h"
 
@@ -49,8 +50,26 @@ void AraEventConditioner::conditionEvent(UsefulAtriStationEvent *theEvent)
   if(theEvent->stationId==ARA_STATION3){
     AraEventConditioner::invertA3Chans(theEvent);
   }
+  trimFirstBlocks(theEvent);
   theEvent->fIsConditioned = true; //mark the event as conditioned
   //now we're done
+}
+
+//! Trimp the first block (SAMPLES_PER_BLOCK) from all graphs
+/*!
+  \param ev the useful atri event pointer
+  \return void
+*/
+
+void AraEventConditioner::trimFirstBlocks(UsefulAtriStationEvent *theEvent){
+  for(Int_t num_channels=0; num_channels<theEvent->fTimes.size(); num_channels++){
+    theEvent->fTimes[num_channels].erase(theEvent->fTimes[num_channels].begin(), theEvent->fTimes[num_channels].begin()+SAMPLES_PER_BLOCK);
+    theEvent->fVolts[num_channels].erase(theEvent->fVolts[num_channels].begin(), theEvent->fVolts[num_channels].begin()+SAMPLES_PER_BLOCK);
+  }
+  //record the trimming
+  std::stringstream ss;
+  ss<<"trim_first_blocks_all";
+  theEvent->fConditioningList.push_back(ss.str());
 }
 
 

--- a/AraEvent/AraEventConditioner.cxx
+++ b/AraEvent/AraEventConditioner.cxx
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <cstring>
 #include <cstdlib>
+#include <sstream>
 
 #include "UsefulAtriStationEvent.h"
 #include "AraEventConditioner.h"
@@ -59,8 +60,26 @@ void AraEventConditioner::conditionEvent(UsefulAtriStationEvent *theEvent)
   \return void
 */
 void AraEventConditioner::invertA3Chans(UsefulAtriStationEvent *theEvent){
-  int chan;
-  
-  chan=0;
+  //make a list of channels we want to invert
+  std::vector<Int_t> list_to_invert;
+  list_to_invert.push_back(0);
+  list_to_invert.push_back(4);
+  list_to_invert.push_back(8);
 
+  //loop over that list and invert them (multiply by -1)
+  for(int i=0; i<list_to_invert.size(); i++){
+    //get the elec chan
+    Int_t rf_chan = list_to_invert[i];
+    Int_t elec_chan = AraGeomTool::Instance()->getElecChanFromRFChan(rf_chan, theEvent->stationId);
+    
+    //perform inversion on every sample
+    for(Int_t samp=0; samp<theEvent->fTimes[elec_chan].size(); samp++){
+      theEvent->fVolts[elec_chan][samp]*=-1.;
+    }
+
+    //record the inversion
+    std::stringstream ss;
+    ss<<"invert_ch"<<rf_chan;
+    theEvent->fCondtioningList.push_back(ss.str());
+  }
 }

--- a/AraEvent/AraEventConditioner.h
+++ b/AraEvent/AraEventConditioner.h
@@ -37,6 +37,7 @@ class AraEventConditioner : public TObject
 
   private:
     void invertA3Chans(UsefulAtriStationEvent *theEvent);
+    void trimFirstBlocks(UsefulAtriStationEvent *theEvent);
 
   protected:
     static AraEventConditioner *fgInstance;  ///< protect against multiple instances

--- a/AraEvent/AraEventConditioner.h
+++ b/AraEvent/AraEventConditioner.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////////
+/////  AraEvenetConditioner.h        Conditioner                         /////
+/////                                                                    /////
+/////  Description:                                                      /////
+/////     The Ara class for conditioningevents                           /////
+/////  Author: Brian Clark (clark.2668@osu.edu)                          /////
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef ARAEVENTCONDITIONER_H
+#define ARAEVENTCONDITIONER_H
+
+//Includes
+#include <TObject.h>
+#include "araSoft.h"
+#include "araAtriStructures.h"
+#include "araIcrrStructures.h"
+#include "araIcrrDefines.h"
+
+class UsefulAtriStationEvent;
+
+//!  Part of AraEvent library. The conditioner takes real ATRI pointer and applies some conditioning after calibration
+/*!
+  The Ara Event Conditioner
+  \ingroup rootclasses
+*/
+class AraEventConditioner : public TObject
+{
+  public:
+    AraEventConditioner(); ///< Default constructor
+    ~AraEventConditioner(); ///< Destructor
+
+   //Instance generator
+   static AraEventConditioner*  Instance(); ///< Generates an instance of AraEventConditioner to use
+
+   //function to condition an event
+   void conditionEvent(UsefulAtriStationEvent *theEvent);
+
+  private:
+    void invertA3Chans(UsefulAtriStationEvent *theEvent);
+
+  protected:
+    static AraEventConditioner *fgInstance;  ///< protect against multiple instances
+
+  ClassDef(AraEventConditioner,1);
+};
+
+#endif //ARAEVENTCONDITIONER_H

--- a/AraEvent/AraEventConditioner.h
+++ b/AraEvent/AraEventConditioner.h
@@ -36,8 +36,9 @@ class AraEventConditioner : public TObject
    void conditionEvent(UsefulAtriStationEvent *theEvent);
 
   private:
-    void invertA3Chans(UsefulAtriStationEvent *theEvent);
-    void trimFirstBlocks(UsefulAtriStationEvent *theEvent);
+    void invertA3Chans(UsefulAtriStationEvent *theEvent); ///<invert channels 0, 4, 8 of A3
+    void trimFirstBlock(UsefulAtriStationEvent *theEvent); ///<remove the first block from all waveforms
+    void makeMeanZero(UsefulAtriStationEvent *theEvent); ///<make the mean zero (to be used *after* trimFirstBlock)
 
   protected:
     static AraEventConditioner *fgInstance;  ///< protect against multiple instances

--- a/AraEvent/AraQualCuts.cxx
+++ b/AraEvent/AraQualCuts.cxx
@@ -136,11 +136,12 @@ bool AraQualCuts::hasTooFewBlocks(UsefulAtriStationEvent *realEvent)
   bool hasTooFewBlocks=false;
   for(int chan=0; chan<realEvent->getNumRFChannels(); chan++){
     TGraph* gr = realEvent->getGraphFromRFChan(chan); //get the waveform
-    if(gr->GetN()<SAMPLES_PER_BLOCK){
+    int N = gr->GetN();
+    delete gr;
+    if(N<SAMPLES_PER_BLOCK){
       hasTooFewBlocks=true;
       break;
     }
-    delete gr;
   }
   return hasTooFewBlocks;
 }

--- a/AraEvent/CMakeLists.txt
+++ b/AraEvent/CMakeLists.txt
@@ -11,12 +11,12 @@ AraEventCalibrator.h        AtriEventHkData.h           RawAraGenericHeader.h   
 AtriSensorHkData.h          RawAraStationEvent.h        UsefulAraStationEvent.h     araSoft.h  			AraGeomTool.h
 FullIcrrHkEvent.h           RawAtriSimpleStationEvent.h UsefulAtriStationEvent.h    AraRawIcrrRFChannel.h       IcrrHkData.h                
 RawAtriStationBlock.h       UsefulIcrrStationEvent.h   	AraRootVersion.h            IcrrTriggerMonitor.h        RawAtriStationEvent.h       
-araAtriStructures.h	    AraCalAntennaInfo.h         AraSunPos.h         AraQualCuts.h
+araAtriStructures.h	    AraCalAntennaInfo.h         AraSunPos.h         AraQualCuts.h         AraEventConditioner.h
 	  )
 
 #Source for library
 File(GLOB ${libname}Source AraAntennaInfo.cxx  AraCalAntennaInfo.cxx          AraRawIcrrRFChannel.cxx       FullIcrrHkEvent.cxx           RawAraStationEvent.cxx        RawIcrrStationEvent.cxx       UsefulIcrrStationEvent.cxx  AraEventCalibrator.cxx     AraStationInfo.cxx            IcrrHkData.cxx                 RawIcrrStationHeader.cxx
-  AtriEventHkData.cxx    RawAtriSimpleStationEvent.cxx	   IcrrTriggerMonitor.cxx        RawAtriStationBlock.cxx       UsefulAraStationEvent.cxx     AraGeomTool.cxx               AtriSensorHkData.cxx          RawAraGenericHeader.cxx     RawAtriStationEvent.cxx       UsefulAtriStationEvent.cxx          AraSunPos.cxx           AraQualCuts.cxx
+  AtriEventHkData.cxx    RawAtriSimpleStationEvent.cxx	   IcrrTriggerMonitor.cxx        RawAtriStationBlock.cxx       UsefulAraStationEvent.cxx     AraGeomTool.cxx               AtriSensorHkData.cxx          RawAraGenericHeader.cxx     RawAtriStationEvent.cxx       UsefulAtriStationEvent.cxx          AraSunPos.cxx           AraQualCuts.cxx           AraEventConditioner.cxx
 	  )
 
 #Generate the ROOT dictionary using the ROOT CMake function

--- a/AraEvent/LinkDef.h
+++ b/AraEvent/LinkDef.h
@@ -23,6 +23,7 @@
 #pragma link C++ class AraStationInfo+;
 #pragma link C++ class AraGeomTool+;
 #pragma link C++ class AraEventCalibrator+;
+#pragma link C++ class AraEventConditioner+;
 #pragma link C++ class RawAtriStationBlock+;
 #pragma link C++ class RawAtriStationEvent+;
 #pragma link C++ class RawAraGenericHeader+;

--- a/AraEvent/UsefulAtriStationEvent.cxx
+++ b/AraEvent/UsefulAtriStationEvent.cxx
@@ -94,9 +94,7 @@ TGraph *UsefulAtriStationEvent::getGraphFromRFChan(int chan)
   }
   
   TGraph *grRet = getGraphFromElecChan(elecChan);
-  TGraph *grOut = trimGraph(grRet, 20.); //trim off 20 ns from the *front* (remove the first block essentially)
-  delete grRet;
-  return grOut;
+  return grRet;
 }
 
 
@@ -180,33 +178,4 @@ Int_t UsefulAtriStationEvent::getNumRFChannels()
 {
   return AraGeomTool::Instance()->getStationInfo(stationId)->getNumRFChans();
 
-}
-
-/*
-Trim first 20ns from the waveform
-inputs: graph to be trimmed, amount to trim from the front of the graph
-returns: pointer to new trimmed graph
-*/
-TGraph *UsefulAtriStationEvent::trimGraph(TGraph *grIn, double trim_value){
-
-  //load the old X and Y arrays
-  double *oldX = grIn->GetX();
-  double *oldY = grIn->GetY();
-  
-  //record the first sample
-  double first_time = oldX[0];
-
-  //create holders for the trimmed X and Y arrays
-  std::vector<double> newX;
-  std::vector<double> newY;
-
-  for(int samp=0; samp<grIn->GetN(); samp++){ //loop over samples in the old waveform
-    if(oldX[samp]>first_time+trim_value){ //if the time of the sample is > the trim amount, keep it
-      newX.push_back(oldX[samp]); //record the x value
-      newY.push_back(oldY[samp]); //record the y value
-    }
-  }
-
-  TGraph *grOut = new TGraph(newX.size(), &newX[0], &newY[0]);
-  return grOut;
 }

--- a/AraEvent/UsefulAtriStationEvent.cxx
+++ b/AraEvent/UsefulAtriStationEvent.cxx
@@ -94,15 +94,8 @@ TGraph *UsefulAtriStationEvent::getGraphFromRFChan(int chan)
   }
   
   TGraph *grRet = getGraphFromElecChan(elecChan);
-
-  // for A3, channels 0, 4, 8, need to invert the voltages
-  // see talk by B Clark (http://ara.physics.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=1790)
-  if(stationId==3 && (chan==0 || chan==4 || chan==8)){
-    invertGraph(grRet);
-  }
   TGraph *grOut = trimGraph(grRet, 20.); //trim off 20 ns from the *front* (remove the first block essentially)
   delete grRet;
-  
   return grOut;
 }
 
@@ -187,18 +180,6 @@ Int_t UsefulAtriStationEvent::getNumRFChannels()
 {
   return AraGeomTool::Instance()->getStationInfo(stationId)->getNumRFChans();
 
-}
-
-/*
-Vertically invert a waveform
-necessary for some channels in A3 (RF chans 0, 4, 8)
-*/
-void UsefulAtriStationEvent::invertGraph(TGraph *gr){
-  double t1, v1;
-  for(int i=0; i<gr->GetN(); i++){ // loop over all samples in waveform
-    gr->GetPoint(i,t1,v1); //g et the voltage point
-    gr->SetPoint(i,t1,-v1); // re-set the voltage point, multiplying by -1
-  }
 }
 
 /*

--- a/AraEvent/UsefulAtriStationEvent.cxx
+++ b/AraEvent/UsefulAtriStationEvent.cxx
@@ -9,6 +9,7 @@
 
 #include "UsefulAtriStationEvent.h"
 #include "AraEventCalibrator.h"
+#include "AraEventConditioner.h"
 #include "FFTtools.h"
 #include "AraGeomTool.h"
 #include "TH1.h"
@@ -18,18 +19,23 @@
 ClassImp(UsefulAtriStationEvent);
 
 AraEventCalibrator *fCalibrator;
+AraEventConditioner *fConditioner;
 
 UsefulAtriStationEvent::UsefulAtriStationEvent() 
 {
-   //Default Constructor
+  //Default Constructor
   fNumChannels=0;
   fCalibrator=0;
+  fConditioner=0;
+  fIsConditioned=0;
 }
 
 UsefulAtriStationEvent::~UsefulAtriStationEvent() {
    //Default Destructor
   fNumChannels=0;
   fCalibrator=0;
+  fConditioner=0;
+  fIsConditioned=0;
 }
 
 UsefulAtriStationEvent::UsefulAtriStationEvent(RawAtriStationEvent *rawEvent, AraCalType::AraCalType_t calType)
@@ -38,8 +44,9 @@ UsefulAtriStationEvent::UsefulAtriStationEvent(RawAtriStationEvent *rawEvent, Ar
   fCalibrator=AraEventCalibrator::Instance();
   fNumChannels=0;
   fCalibrator->calibrateEvent(this,calType);
-  //  fprintf(stderr, "UsefulAtriStationEvent::UsefulAtriStationEvent() -- finished constructing event\n");  //DEBUG
-
+  fIsConditioned=0;
+  fConditioner=AraEventConditioner::Instance();
+  fConditioner->conditionEvent(this);
 }
 
 

--- a/AraEvent/UsefulAtriStationEvent.h
+++ b/AraEvent/UsefulAtriStationEvent.h
@@ -44,7 +44,6 @@ class UsefulAtriStationEvent: public RawAtriStationEvent, public UsefulAraStatio
     TGraph *getFFTForRFChan(int chan); ///<Utility function for webplotter, all channels are interpolated to 0.5 ns - the returned TGraph is from FFTtools::makePowerSpectrumMilliVoltsNanoS$
     TH1D *getFFTHistForRFChan(int chan); ///< Utility function for webplotter -- produces a TH1D form of getFFTForRFChan(int chan)
     int fillFFTHistoForRFChan(int chan, TH1D *histFFT); ///< Utility function for webplotter
-    void invertGraph(TGraph *gr); ///<Invert the graph; that is, multiply by -1
     TGraph *trimGraph(TGraph *grIn, double trim_value); ///<trim grIn by trim_value (ns) at the *beginning* of the waveform
 
     //Calibrated data

--- a/AraEvent/UsefulAtriStationEvent.h
+++ b/AraEvent/UsefulAtriStationEvent.h
@@ -54,7 +54,7 @@ class UsefulAtriStationEvent: public RawAtriStationEvent, public UsefulAraStatio
 
     //to track conditioning
     bool fIsConditioned;
-    std::vector<std::string> fCondtioningList;
+    std::vector<std::string> fConditioningList;
 
   ClassDef(UsefulAtriStationEvent,1);
 };

--- a/AraEvent/UsefulAtriStationEvent.h
+++ b/AraEvent/UsefulAtriStationEvent.h
@@ -32,30 +32,31 @@
 */
 class UsefulAtriStationEvent: public RawAtriStationEvent, public UsefulAraStationEvent
 {
- public:
-   UsefulAtriStationEvent(); ///< Default constructor
-   UsefulAtriStationEvent(RawAtriStationEvent *rawEvent, AraCalType::AraCalType_t calType=AraCalType::kVoltageTime); ///< Constructor from RawAtriStationEvent object. This uses AraEventCalibrator to apply calibrations to the event.
-   ~UsefulAtriStationEvent(); ///< Destructor
+  public:
+    UsefulAtriStationEvent(); ///< Default constructor
+    UsefulAtriStationEvent(RawAtriStationEvent *rawEvent, AraCalType::AraCalType_t calType=AraCalType::kVoltageTime); ///< Constructor from RawAtriStationEvent object. This uses AraEventCalibrator to apply calibrations to the event.
+    ~UsefulAtriStationEvent(); ///< Destructor
 
+    Int_t getNumElecChannels() {return fNumChannels;} ///< Returns the number of electronics channels
+    Int_t getNumRFChannels(); ///< Returns the number of RF channels - NB this may differ from the number of electronics channels
+    TGraph *getGraphFromElecChan(int chanId); ///< Returns the voltages-time graph for the appropriate electronics channel
+    TGraph *getGraphFromRFChan(int chanId); ///< Returns the voltage-time graph for the appropriate rf channel
+    TGraph *getFFTForRFChan(int chan); ///<Utility function for webplotter, all channels are interpolated to 0.5 ns - the returned TGraph is from FFTtools::makePowerSpectrumMilliVoltsNanoS$
+    TH1D *getFFTHistForRFChan(int chan); ///< Utility function for webplotter -- produces a TH1D form of getFFTForRFChan(int chan)
+    int fillFFTHistoForRFChan(int chan, TH1D *histFFT); ///< Utility function for webplotter
+    void invertGraph(TGraph *gr); ///<Invert the graph; that is, multiply by -1
+    TGraph *trimGraph(TGraph *grIn, double trim_value); ///<trim grIn by trim_value (ns) at the *beginning* of the waveform
 
-   Int_t getNumElecChannels() {return fNumChannels;} ///< Returns the number of electronics channels
-   Int_t getNumRFChannels(); ///< Returns the number of RF channels - NB this may differ from the number of electronics channels
-   TGraph *getGraphFromElecChan(int chanId); ///< Returns the voltages-time graph for the appropriate electronics channel
-   TGraph *getGraphFromRFChan(int chanId); ///< Returns the voltage-time graph for the appropriate rf channel
-   TGraph *getFFTForRFChan(int chan); ///<Utility function for webplotter, all channels are interpolated to 0.5 ns - the returned TGraph is from FFTtools::makePowerSpectrumMilliVoltsNanoS$
-   TH1D *getFFTHistForRFChan(int chan); ///< Utility function for webplotter -- produces a TH1D form of getFFTForRFChan(int chan)
-   int fillFFTHistoForRFChan(int chan, TH1D *histFFT); ///< Utility function for webplotter
-   void invertGraph(TGraph *gr); ///<Invert the graph; that is, multiply by -1
-   TGraph *trimGraph(TGraph *grIn, double trim_value); ///<trim grIn by trim_value (ns) at the *beginning* of the waveform
+    //Calibrated data
+    Int_t fNumChannels; ///< The number of channels
+    std::map< Int_t, std::vector <Double_t> > fTimes; ///< The times of samples
+    std::map< Int_t, std::vector <Double_t> > fVolts; ///< The voltages of samples
 
-   //Calibrated data
-   Int_t fNumChannels; ///< The number of channels
-   std::map< Int_t, std::vector <Double_t> > fTimes; ///< The times of samples
-   std::map< Int_t, std::vector <Double_t> > fVolts; ///< The voltages of samples
-
+    //to track conditioning
+    bool fIsConditioned;
+    std::vector<std::string> fCondtioningList;
 
   ClassDef(UsefulAtriStationEvent,1);
 };
-
 
 #endif //USEFULATRISTATIONEVENT_H

--- a/AraEvent/UsefulAtriStationEvent.h
+++ b/AraEvent/UsefulAtriStationEvent.h
@@ -44,7 +44,6 @@ class UsefulAtriStationEvent: public RawAtriStationEvent, public UsefulAraStatio
     TGraph *getFFTForRFChan(int chan); ///<Utility function for webplotter, all channels are interpolated to 0.5 ns - the returned TGraph is from FFTtools::makePowerSpectrumMilliVoltsNanoS$
     TH1D *getFFTHistForRFChan(int chan); ///< Utility function for webplotter -- produces a TH1D form of getFFTForRFChan(int chan)
     int fillFFTHistoForRFChan(int chan, TH1D *histFFT); ///< Utility function for webplotter
-    TGraph *trimGraph(TGraph *grIn, double trim_value); ///<trim grIn by trim_value (ns) at the *beginning* of the waveform
 
     //Calibrated data
     Int_t fNumChannels; ///< The number of channels


### PR DESCRIPTION
This branch introduces the AraEventConditioner class, which enables us to condition waveforms further after we calibrate them.

It moves the previous trimGraph function from the UsefulAtriStationEvent class to the AraEventConditioner class, which is a more appropriate place for it.