### PR TITLE
don't condition primitive calibration types

### DIFF
--- a/AraEvent/UsefulAtriStationEvent.cxx
+++ b/AraEvent/UsefulAtriStationEvent.cxx
@@ -45,8 +45,13 @@ UsefulAtriStationEvent::UsefulAtriStationEvent(RawAtriStationEvent *rawEvent, Ar
   fNumChannels=0;
   fCalibrator->calibrateEvent(this,calType);
   fIsConditioned=0;
-  fConditioner=AraEventConditioner::Instance();
-  fConditioner->conditionEvent(this);
+
+  // only run the conditioner if we want fully calibrated waveforms
+  // i.e. if the user asks for kNoCalib or kJustPed etc, we should not condition
+  if(calType > AraCalType::kADC){
+    fConditioner=AraEventConditioner::Instance();
+    fConditioner->conditionEvent(this);
+  }
 }
 
 


### PR DESCRIPTION
make it so that event conditioning doesn't happen if the user is asking for a primitive calibration type, e.g. kNoCalib or kJustPed