### PR TITLE
Update to the RayTraceCorrelator

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -15,7 +15,7 @@
 #include "RayTraceCorrelator.h"
 #include "RayTraceCorrelator_detail.h"
 
-void RayTraceCorrelator::SetupStationInfo(int stationID, int unixTime) { 
+void RayTraceCorrelator::SetupStationInfo(int stationID, int numAntennas) { 
     char errorMessage[400];
 
     // set station ID
@@ -25,26 +25,11 @@ void RayTraceCorrelator::SetupStationInfo(int stationID, int unixTime) {
     }
     stationID_ = stationID;
 
-    // set unixTime
-    if(unixTime<0 || isnan(unixTime)){ // testbed through A5 is supported
-        sprintf(errorMessage,"Requested unixTime (%d) is not supported\n", unixTime);
+    if(numAntennas < 1 || isnan(numAntennas)){
+        sprintf(errorMessage,"Number of antennas (%d) is not supported\n", numAntennas);
         throw std::invalid_argument(errorMessage);
     }
-    unixTime_ = unixTime;
-
-    // save the station info object
-    // and count the number of non-surface channels
-    AraGeomTool *geomTool = AraGeomTool::Instance();
-    auto araStationInfo = geomTool->getStationInfo(stationID_, unixTime);
-    int numAnts = (int) araStationInfo->getNumRFChans();
-    int num_not_surface = 0;
-    for(int ant=0; ant<numAnts; ant++){
-        auto pol = araStationInfo->getAntennaInfo(ant)->polType;
-        if(pol!= AraAntPol::kSurface){
-            num_not_surface++;
-        }
-    }
-    numAntennas_ = num_not_surface;
+    numAntennas_ = numAntennas;
 }
 
 void RayTraceCorrelator::SetAngularConfig(double angularSize){
@@ -78,14 +63,32 @@ void RayTraceCorrelator::SetRadius(double radius){
     radius_ = radius;
 }
 
-void RayTraceCorrelator::SetIceModel(int iceModel){
-    if(iceModel<0 || isnan(iceModel)){
-        char errorMessage[400];
-        sprintf(errorMessage,"Requested icemodel (%e) is has an\n", iceModel);
-        throw std::invalid_argument(errorMessage);        
+void RayTraceCorrelator::SetTablePaths(const std::string &dirPath, const std::string &refPath){
+
+    char errorMessage[400];
+    struct stat buffer;
+
+    // throw errors if these files don't exist
+    bool dirFileExists = (stat(dirPath.c_str(), &buffer) == 0);
+    if (!dirFileExists ){
+        sprintf(errorMessage,"Direct solution arrival times table is missing (dir file exists %d) ", dirFileExists);
+        throw std::runtime_error(errorMessage);       
     }
-    iceModel_ = iceModel;
+    // dirSolTablePath_ = strcpy(dirSolTablePath_, dirPath.c_str());
+    // std::copy(dirPath.begin(), dirPath.end(), dirSolTablePath_);
+    dirSolTablePath_ = dirPath;
+
+    bool refFileExists = (stat(refPath.c_str(), &buffer) == 0);
+    if (!refFileExists){
+        sprintf(errorMessage,"Reflected/refracted solution arrival times table is missing (dir file exists %d) ", refFileExists);
+        throw std::runtime_error(errorMessage);       
+    }
+    // refSolTablePath_ = strcpy(refSolTablePath_, refPath.c_str());
+    // std::copy(refPath.begin(), refPath.end(), refSolTablePath_);
+    refSolTablePath_ = refPath;
 }
+
+
 
 void RayTraceCorrelator::ConfigureArrivalTimesVector(){
     arrivalTimes_.resize(2);
@@ -146,63 +149,43 @@ RayTraceCorrelator::~RayTraceCorrelator()
 	//Default destructor
 }
 
-RayTraceCorrelator::RayTraceCorrelator(int stationID, 
+RayTraceCorrelator::RayTraceCorrelator(int stationID,
+    int numAntennas,
     double radius, 
     double angularSize,
-    int iceModel,
-    int unixTime
+    const std::string &dirSolTablePath, 
+    const std::string &refSolTablePath
     ){
 
     // initialize and sanitize the input immediately
     // afterwards, we can (safely!) only refer to private variables
     this->SetAngularConfig(angularSize);
-    this->SetupStationInfo(stationID, unixTime);
+    this->SetupStationInfo(stationID, numAntennas);
     this->SetRadius(radius);
-    this->SetIceModel(iceModel);
+    this->SetTablePaths(dirSolTablePath, refSolTablePath);
+
 }
 
-void RayTraceCorrelator::LoadTables(const std::string &tableDir){
+void RayTraceCorrelator::LoadTables(){
     char errorMessage[400];
     
-    // verify the directory containing the tables exists
-    struct stat buffer;
-    bool dirExists = (stat(tableDir.c_str(), &buffer) == 0);
-    if(!dirExists){
-        sprintf(errorMessage,"Tables directory (%s) does not exist! Abort!\n", tableDir.c_str());
-        throw std::runtime_error(errorMessage);
-    }
-
-    // set the table file names
-    char directFileName[500];
-    char reflecFileName[500];
-    sprintf(directFileName, "%s/arrivaltimes_station_%d_icemodel_%d_radius_%.2f_angle_%.2f_solution_0.root",
-        tableDir.c_str(), stationID_, iceModel_, radius_, angularSize_);
-    sprintf(reflecFileName, "%s/arrivaltimes_station_%d_icemodel_%d_radius_%.2f_angle_%.2f_solution_1.root",
-        tableDir.c_str(), stationID_, iceModel_, radius_, angularSize_);
-    
-    // throw errors if these files don't exist
-    bool dirFileExists = (stat(directFileName, &buffer) == 0);
-    bool refFileExists = (stat(reflecFileName, &buffer) == 0);
-    if (!dirFileExists || !refFileExists){
-        sprintf(errorMessage,"An arrival times table is missing (dir file exists %d, ref file exists %d) ", dirFileExists, refFileExists);
-        throw std::runtime_error(errorMessage);       
-    }
-
     // load the arrival time tables
     this->ConfigureArrivalTimesVector();
-    this->LoadArrivalTimeTables(directFileName, 0);
-    this->LoadArrivalTimeTables(reflecFileName, 1);
+    this->LoadArrivalTimeTables(dirSolTablePath_, 0);
+    this->LoadArrivalTimeTables(refSolTablePath_, 1);
 }
 
+// FIXME
 std::map< int, std::vector<int> > RayTraceCorrelator::SetupPairs(
-    AraAntPol::AraAntPol_t polSelection, 
+    int stationID,
+    AraGeomTool *geomTool,
+    AraAntPol::AraAntPol_t polSelection,
     std::vector<int> excludedChannels){
     
     // first, figure out what set of antennas is viable to form pairs
     std::vector < int > viableAntennas;
     
-    AraGeomTool *geomTool = AraGeomTool::Instance();
-    auto araStationInfo = geomTool->getStationInfo(this->stationID_, this->unixTime_);
+    auto araStationInfo = geomTool->getStationInfo(stationID);
     for(int ant=0; ant<this->numAntennas_; ant++){
 
         // first, check if this event is allowed

--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -74,8 +74,6 @@ void RayTraceCorrelator::SetTablePaths(const std::string &dirPath, const std::st
         sprintf(errorMessage,"Direct solution arrival times table is missing (dir file exists %d) ", dirFileExists);
         throw std::runtime_error(errorMessage);       
     }
-    // dirSolTablePath_ = strcpy(dirSolTablePath_, dirPath.c_str());
-    // std::copy(dirPath.begin(), dirPath.end(), dirSolTablePath_);
     dirSolTablePath_ = dirPath;
 
     bool refFileExists = (stat(refPath.c_str(), &buffer) == 0);
@@ -83,8 +81,6 @@ void RayTraceCorrelator::SetTablePaths(const std::string &dirPath, const std::st
         sprintf(errorMessage,"Reflected/refracted solution arrival times table is missing (dir file exists %d) ", refFileExists);
         throw std::runtime_error(errorMessage);       
     }
-    // refSolTablePath_ = strcpy(refSolTablePath_, refPath.c_str());
-    // std::copy(refPath.begin(), refPath.end(), refSolTablePath_);
     refSolTablePath_ = refPath;
 }
 

--- a/AraCorrelator/RayTraceCorrelator_support/docs/README.md
+++ b/AraCorrelator/RayTraceCorrelator_support/docs/README.md
@@ -19,13 +19,13 @@ An instance of the RayTraceCorrelator can be called as such:
 
 ```c++
 RayTraceCorrelator *theCorrelator = new RayTraceCorrelator(int station, 
-        double radius, double angular_size, int iceModel, int unixTime
+        double radius, double angular_size, string dirSolTablePath, string refSolTablePath
     );
 ```
 
 After the correlator is created, one must load the tables holding the arrival times:
 ```c++
-theCorrelator->LoadTables("/path/to/tables/");
+theCorrelator->LoadTables();
 ```
 
 The interferometer takes as inputs (1) interpolated waveforms, (2) pairs of antennas which
@@ -45,9 +45,6 @@ from (2) *calculating* the arrival times. For this reason, arrival times
 are stored in tables that are loaded by the correlator.
 Construction of the arrival time tables is technically up to user's preferences, 
 though we usually use AraSim ray tracer.
-Because the AraSim ray tracer is used, the index of refraction
-model is tied to the AraSim `RAY_TRACE_ICE_MODEL_PARAMS` variable.
-This is currently a simple integer.
 A script to calculate the timing tables via AraSim 
 is provided (`makeRTArrivalTimeTables.cpp`). 
 See below for more details on the ice model and using the table generation script.
@@ -119,8 +116,8 @@ the user to specify a few variables:
 - station: this must be an ARA station between 0 (Testbed) and 5 (A5)
 - radius: the distance from the station center of gravity for a putative source
 - angular size: the angular binning (in degrees)
-- icemodel: the ice model, which specifies the depth dependent index of refraction
-- unixtime: default is 0; use actual run time if you like 
+- direct tables path: path to the file containing the direct ray tracing solutions solution timing table
+- reflected tables path: path to the file containing the reflected/refracted ray tracing solution timing tables
 
 #### Angular Size
 The `angularSize` parameter controls the angular binning.
@@ -147,32 +144,6 @@ please use the correct corresponding getter function, e.g.:
 ```c++
 int numPhiBins theCorrelator->GetNumPhiBins();
 ```
-
-#### IceModel Params
-
-AraSim is used as the ray tracer, and so the icemodels are (presently) keyed 
-to the AraSim `RAY_TRACE_ICE_MODEL_PARAMS` variable.
-AraSim always assumes a exponential profile, with the parameters of that
-profile changing.
-See the [AraSim Settings.h](https://github.com/ara-software/AraSim/blob/2758c07dc56fb1a9a784e460306868f0f940b499/Settings.h#L264) file for a list
-of currently available ice models.
-
-Because the correlator doesn't interface with AraSim at all (only the delay tables)
-it should be possible to remove this icemodel key completely.
-And only pass e.g. the path to the tables. See the to-do list.
-
-#### Unixtime
-
-Because the ray trace correlator needs to know how many deep antennas
-are in a station, it does need to talk to the AraGeomTool.
-And since the station geometries change a bit as a function of time,
-it also needs to know the unixtime of the events you would like to correlate.
-Since the number of deep antennas is static for every station except
-maybe A5 (which was merged with the PA DAQ in 2019), it is unlikely
-that is argument will ever be needed. But is provided for future proofing.
-
-An alternative might be to allow the user to specify `numAntennas_` manually.
-See the to-do list.
 
 ## Making Correlation Maps
 
@@ -262,12 +233,13 @@ This is the default behavior in the correlator.
 If you want to turn this behavior off, set the argument to `false`.
 
 ## To Do
-1. Remove the IceModel dependence in the correlator. All the user needs to do is specify the tables.
-2. Remove the unixTime dependence. E.g. let the user specify `numAntennas_` manually?
+1. ~Remove the IceModel dependence in the correlator. All the user needs to do is specify the tables.~ (Done, BAC Sep 2021)
+2. ~Remove the unixTime dependence. E.g. let the user specify `numAntennas_` manually?~ (Done, BAC Sep 2021)
 3. Add support for uniform binning in cos(theta) instead of theta.
-4. Make sure unixTime is getting handled correctly
+4. ~Make sure unixTime is getting handled correctly~ (Done, See 1)
 5. Add helper functions for "get peak," "get max correlation," etc.
 6. ~Add ability to take weights for each pair in the `GetInterferometricMap` function.~ (Done, BAC).
+7. Should we remove the stationID dependence all together?
 
 
 More on 3: This should be done by changing the correlator constructor  

--- a/AraCorrelator/makeRTCorrelationMaps.cxx
+++ b/AraCorrelator/makeRTCorrelationMaps.cxx
@@ -35,24 +35,36 @@ int main(int argc, char **argv)
     /////////////////////////////////////////////////
     /////////////////////////////////////////////////
 
-    // initialize a correlator
+    // setup the paths to our ray tracing tables
     double radius = 300.;
     double angular_size = 1.;
     int iceModel = 0;
-    int unixTime = 0;
-    RayTraceCorrelator *theCorrelator = new RayTraceCorrelator(station, 
-        radius, angular_size, iceModel, unixTime
+    char dirPath[500];
+    char refPath[500];
+    std::string topDir = "/cvmfs/ara.opensciencegrid.org/data/raytrace_tables/";
+    sprintf(dirPath, "%s/arrivaltimes_station_%d_icemodel_%d_radius_%.2f_angle_%.2f_solution_0.root",
+        topDir.c_str(), station, iceModel, radius, angular_size
+    );
+    sprintf(refPath, "%s/arrivaltimes_station_%d_icemodel_%d_radius_%.2f_angle_%.2f_solution_1.root",
+        topDir.c_str(), station, iceModel, radius, angular_size
+    );
+
+    int numAntennas = 16;
+    // initialize a correlator
+    RayTraceCorrelator *theCorrelator = new RayTraceCorrelator(station, numAntennas,
+        radius, angular_size, dirPath, refPath
     );
 
     // and tell it to load up the arrival times tables
-    theCorrelator->LoadTables("/cvmfs/ara.opensciencegrid.org/data/raytrace_tables/");
+    theCorrelator->LoadTables();
 
     // How you set up the pairs is up to you!
     // There are a few helper functions;
     // for example, here we can load all of the VPol pairs.
 
+    AraGeomTool *geomTool = AraGeomTool::Instance();
     std::vector<int> excludedChannels = {15};
-    std::map< int, std::vector<int> > pairs = theCorrelator->SetupPairs(AraAntPol::kVertical, excludedChannels);
+    std::map< int, std::vector<int> > pairs = theCorrelator->SetupPairs(station, geomTool, AraAntPol::kVertical, excludedChannels);
     std::cout<<"Number of pairs "<<pairs.size()<<std::endl;
     for(int i=0; i<pairs.size(); i++){
         printf("Pair %d: %d, %d\n",i,pairs.find(i)->second[0], pairs.find(i)->second[1]);


### PR DESCRIPTION
This update to the RayTraceCorrelator removes the icemodel and unixtime dependencies, which essentially makes the ray trace correlator work on any data, not just ARA data. It also means the tables are not tied to the AraSim iceModel paradigm.