### PR TITLE
Adjust the RTC API

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -82,21 +82,33 @@ class RayTraceCorrelator : public TObject
         void LoadTables();
 
 
+        //! function to get correlation functions
+        /*!
+            \param pairs a std::map of pair indices to antenna indices
+            \param interpolatedWaveforms a std::map of antenna indices to interpolated waveforms
+            \param applyHilbertEnvelope whether or not to apply hilbert enveloping to the correlation functions
+            \return a std::vector of the correlation functions (one for each pair)
+        */
+        std::vector<TGraph*> GetCorrFunctions(
+            std::map<int, std::vector<int> > pairs,
+            std::map<int, TGraph*> interpolatedWaveforms,
+            bool applyHilbertEnvelope = true
+        );
+
+
         //! function to get an interferometric map
         /*!
-            \param interpolatedWaveforms a std::map of antenna numbers to interpolated waveforms
             \param pairs a std::map of antenna pairs
+            \param corrFunctions a std::vector of correlation functions, one for each pair in pairs (in that order!)
             \param solNum whether to have the first or second (0 or 1) solution hypothesis
-            \param applyHilbertEnvelope whether or not to apply a hilbert envelope to the correlation function
             \param weights weights to apply to each map; default = equal weights, or 1/pairs.size()
             \return a 2D histogram with the values filled with the interferometric sums
         */
         TH2D* GetInterferometricMap(
-            std::map<int, TGraph*> interpolatedWaveforms,
             std::map<int, std::vector<int> > pairs,
+            std::vector<TGraph*> corrFunctions,
             int solNum,
-            std::map<int, double> weights = {},
-            bool applyHilbertEnvelope = true
+            std::map<int, double> weights = {}
         );
 
 
@@ -123,6 +135,15 @@ class RayTraceCorrelator : public TObject
             \return TGraph* the cross-correlation function
         */
         TGraph* getCorrelationGraph_WFweight(TGraph * gr1, TGraph * gr2);
+
+
+        //! a function to get a correlation graph with the normalization used in the OSU A2/3 Diffuse Analysis
+        /*!
+            \param gr1 the graph to be cross correlated
+            \param gr2 the second graph to be cross correlated
+            \return TGraph* the cross-correlation function
+        */
+        TGraph* getCorrelationGraph_OSUNormalization(TGraph * gr1, TGraph * gr2);
 
 
         //! a function to get the un-normalized cross correlation function between two ararys

--- a/AraCorrelator/RayTraceCorrelator_support/docs/README.md
+++ b/AraCorrelator/RayTraceCorrelator_support/docs/README.md
@@ -67,6 +67,17 @@ In particular:
 - If the user wants a "single-pair" map (the contribution of a single antenna pair to the overall map), just pass that single pair to the correlator.
 - The user can correlate any arbitrary mix of waveforms. E.g. just VPol, just HPol, but also cross-polarization (VPol and HPol). This also allows a user to dynamically adjust what waveforms are used for a specific event, for example, by only including channels above a specific SNR threshold.
 
+Calculating the correlation functions is actually separate
+from calling the map making rountines. This is on purpose.
+The caluclation of the correlation function is the most expensive
+part of the routine by about a factor of 3-4.
+Meaning that 70%-ish of the time is spent creating the correlation
+functions, not on actually sampling them on the spatial grid.
+So if you need to make >=1 map (e.g. D and R, multiple radii, etc.),
+it is always in our favor to "cache" the waveforms in this way.
+This also makes it easier to examing the correlation functions
+directly for debugging purposes.
+
 ### History
 The "original" RayTraceCorrelator was developed by Eugene Hong and Carl Pfender
 at Ohio State circa 2013. Thanks for all their hard work!
@@ -170,7 +181,6 @@ for a crash-course.
 
 And one optional arguments:
 - weights: weights to apply to each pair during the map making
-
 
 ### Waveforms
 

--- a/AraCorrelator/RayTraceCorrelator_support/docs/README.md
+++ b/AraCorrelator/RayTraceCorrelator_support/docs/README.md
@@ -28,12 +28,14 @@ After the correlator is created, one must load the tables holding the arrival ti
 theCorrelator->LoadTables();
 ```
 
-The interferometer takes as inputs (1) interpolated waveforms, (2) pairs of antennas which
-are to be included in the map, and (3) the solution hypothesis (direct or reflected/refracted).
+The interferometer takes as inputs (1) pairs of antennas which
+are to be included in the map, (2) correlation functions, 
+and (3) the solution hypothesis (direct or reflected/refracted).
 The map making routine returns a ROOT TH2D, and can be called like:
 
 ```c++
-TH2D *map = theCorrelator->GetInterferometricMap(waveforms, pairs, solution);
+std::vector<TGraph*> corr_funcs = theCorrelator->GetCorrFunctions(pairs, wavforms);
+TH2D *map = theCorrelator->GetInterferometricMap(pairs, corr_funcs, solution);
 ```
 
 For more detailed discussion, see below, or see the example.
@@ -147,9 +149,17 @@ int numPhiBins theCorrelator->GetNumPhiBins();
 
 ## Making Correlation Maps
 
+First, we must calculate the correlation functions.
+There are two arguments to the `GetCorrFuncs` routine:
+- pairs: a list of pairs of antennas to be correlated together, with pair indices (as keys) to their respective antennas (as values)
+- interpolated waveforms: a std::map of interpolated waveforms, with antenna numbers as keys and waveforms as values
+
+And one optional argument:
+- whether or not to apply hilbert smoothing to the correlation function
+
 There are three arguments to the `GetInterferometricMap` routine:
-- waveforms: a map of antennas (as keys) to their waveforms (as values)
-- radius: a map of pair indices (as keys) to their respective antennas (as values)
+- pairs: a list of pairs of antennas to be correlated together, with pair indices (as keys) to their respective antennas (as values)
+- correlation functions: a vector of correlation functions for each pair
 - solution: what solution hypothesis to assume (direct or reflected/refracted)
 
 We use C++ maps to make handling things easier. Maps are much
@@ -158,14 +168,13 @@ easier to use than you might think
 See e.g. [this page](https://www.freecodecamp.org/news/c-plus-plus-map-explained-with-examples/)
 for a crash-course.
 
-And two optional arguments:
+And one optional arguments:
 - weights: weights to apply to each pair during the map making
-- applyHilbertEnvelope: whether or not to take the hilbert envelope of the correlation functions
 
 
 ### Waveforms
 
-The waveforms need to be presented to the correlator as a map of
+The waveforms need to be presented to the correlation routine as a map of
 antenna indices to waveforms:
 
 ```c++

--- a/AraCorrelator/makeRTCorrelationMaps.cxx
+++ b/AraCorrelator/makeRTCorrelationMaps.cxx
@@ -104,9 +104,10 @@ int main(int argc, char **argv)
             interpolatedWaveforms[i] = grInt;
             delete gr;
         }
+        std::vector<TGraph*> corrFunctions = theCorrelator->GetCorrFunctions(pairs, interpolatedWaveforms); // apply Hilbert envelope is default
 
         // get the map
-        TH2D *dirMap = theCorrelator->GetInterferometricMap(interpolatedWaveforms, pairs, 0); // direct solution
+        TH2D *dirMap = theCorrelator->GetInterferometricMap(pairs, corrFunctions, 0); // direct solution
 
         // draw and save the map
         gStyle->SetOptStat(0);
@@ -135,6 +136,9 @@ int main(int argc, char **argv)
         delete dirMap;
         for(int i=0; i<16; i++){
             delete interpolatedWaveforms[i];
+        }
+        for(int i=0; i<corrFunctions.size(); i++){
+            delete corrFunctions[i];
         }
         delete realAtriEvPtr;
 


### PR DESCRIPTION
The major change here is a modification to the Ray Trace Correlator API. Namely that it is now the users responsibility to calculate the correlation function themselves.

This is a big win in the case where you want to make multiple maps. It turns out making the correlation graphs is about 70% of the run time of the correlator. So if you need to make multiple maps (e.g. D'n'R, radii scans, etc.) it is a major advantage to have the correlation functions cached.