### PR TITLE
Updating CommonMode() step and High ADC treatment for A5

### DIFF
--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1821,7 +1821,12 @@ Int_t AraEventCalibrator::numberOfPedestalValsInFile(char *fileName){
     return numPedVals;
 }
 
-//! Apply conversion parameter on each ADC sample
+/*! 
+    Apply conversion parameter on each ADC sample
+    Currently, that way to treat for the loaded conversion table is optimized for just A2/3 and A5 
+    And default treatment for the loaded conversion table is following A2/3 optimization
+    In the future, If the conversion table for A1/4 has a different number of parameters or need different treatment, It need to be updated 
+*/
 /*!
     \param adcCountsIn ADC value from the WF sample 
     \param dda corresponding dda board number of adcCountsIn

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1823,7 +1823,7 @@ Int_t AraEventCalibrator::numberOfPedestalValsInFile(char *fileName){
 
 /*! 
     Apply conversion parameter on each ADC sample
-    Currently, that way to treat for the loaded conversion table is optimized for just A2/3 and A5 
+    Currently, the way to treat for the loaded conversion table is optimized for just A2/3 and A5 
     And default treatment for the loaded conversion table is following A2/3 optimization
     In the future, If the conversion table for A1/4 has a different number of parameters or need different treatment, It need to be updated 
 */

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1933,7 +1933,7 @@ Double_t AraEventCalibrator::convertADCtoMilliVolts(Double_t adcCountsIn, int dd
 
         }
         else {
-            if (station != 5){
+            if (stationId != 5){
                 //! here is the alternative calibration (used only for A2 and A3) if the ADC count exceeds 400
                 if(adcCounts>0) {
                     volts = fAtriSampleHighADCVoltsConversion[dda][chan][block][sample][0] 


### PR DESCRIPTION
**1. place CommonMode() step before TimingCalibrationAndBadSampleReomval() step**

This function is subtracting DDA ch5 value from DDA ch1 ~ 4.
But the purpose of this function is unknown. And the return of the `hasCommonMode ()` is always `kFalse`.
Since it will only work when the number of samples between DDA ch 1~4 and ch 5 is the same,
It is placed before `TrimFirstBlock()` and `TimingCalibrationAndBadSampleReomval()`

**2. High ADC treatment for A5**

For A5, since there is no high ADC calibration data, use ADC count for voltage calibration result in case A5 encounters high ADC count (out of -500 ~ 500 ADC range)
Not sure of contents of the `araAtriStation5highAdcToVoltsConv.txt` table.
