### PR TITLE
Adding new CalType mode

### DIFF
--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -35,6 +35,7 @@
 Bool_t AraCalType::hasTrimFirstBlock(AraCalType::AraCalType_t calType)
 {
     //return kFALSE; ///< Just in case, analyzers want to see 1st block on kLatestCalib
+    if(calType==kJustUnwrap) return kTRUE;  ///< For raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;
 }
@@ -57,6 +58,7 @@ Bool_t AraCalType::hasInvertA3Chans(AraCalType::AraCalType_t calType)
 */
 Bool_t AraCalType::hasADCZeroMean(AraCalType::AraCalType_t calType)
 {
+    if(calType==kLatestCalibWithOutZeroMean) return kFALSE; ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;    
 }
@@ -68,6 +70,7 @@ Bool_t AraCalType::hasADCZeroMean(AraCalType::AraCalType_t calType)
 */
 Bool_t AraCalType::hasVoltZeroMean(AraCalType::AraCalType_t calType)
 {
+    if(calType==kLatestCalibWithOutZeroMean) return kFALSE; ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;
 }
@@ -109,6 +112,7 @@ Bool_t AraCalType::hasInterleaveCalib(AraCalType::AraCalType_t calType)
 
 Bool_t AraCalType::hasBinWidthCalib(AraCalType::AraCalType_t calType)
 { 
+    if(calType==kJustUnwrap) return kTRUE; ///< For raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType>=kFirstCalib)
         return kTRUE;
     return kFALSE;
@@ -129,6 +133,7 @@ Bool_t AraCalType::hasClockAlignment(AraCalType::AraCalType_t calType)
 
 Bool_t AraCalType::hasPedestalSubtraction(AraCalType::AraCalType_t calType)
 { 
+    if(calType==kJustUnwrap) return kFALSE; ///< For raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType==kNoCalib) return kFALSE;
     return kTRUE;
 }

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1821,7 +1821,12 @@ Int_t AraEventCalibrator::numberOfPedestalValsInFile(char *fileName){
     return numPedVals;
 }
 
-//! Apply conversion parameter on each ADC sample
+/*! 
+    Apply conversion parameter on each ADC sample
+    Currently, that way to treat for the loaded conversion table is optimized for just A2/3 and A5 
+    And default treatment for the loaded conversion table is following A2/3 optimization
+    In the future, If the conversion table for A1/4 has a different number of parameters or need different treatment, It need to be updated 
+*/
 /*!
     \param adcCountsIn ADC value from the WF sample 
     \param dda corresponding dda board number of adcCountsIn

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1823,7 +1823,7 @@ Int_t AraEventCalibrator::numberOfPedestalValsInFile(char *fileName){
 
 /*! 
     Apply conversion parameter on each ADC sample
-    Currently, that way to treat for the loaded conversion table is optimized for just A2/3 and A5 
+    Currently, the way to treat for the loaded conversion table is optimized for just A2/3 and A5 
     And default treatment for the loaded conversion table is following A2/3 optimization
     In the future, If the conversion table for A1/4 has a different number of parameters or need different treatment, It need to be updated 
 */

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -35,6 +35,7 @@
 Bool_t AraCalType::hasTrimFirstBlock(AraCalType::AraCalType_t calType)
 {
     //return kFALSE; ///< Just in case, analyzers want to see 1st block on kLatestCalib
+    if(calType==kOnlyPed) return kFALSE; ///< Get the pedestal values for the corresponding raw WF, 19-12-2021 -MK-
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;
 }
@@ -46,8 +47,9 @@ Bool_t AraCalType::hasTrimFirstBlock(AraCalType::AraCalType_t calType)
 */
 Bool_t AraCalType::hasInvertA3Chans(AraCalType::AraCalType_t calType)
 {
-    if(calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
-        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+    if(calType==kOnlyGoodADC      ///< Get the raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
+        || calType==kOnlyPed      ///< Get the pedestal values for the corresponding raw WF
+        || calType==kOnlyGoodPed) ///< Get the pedestal values for the corresponding raw WF without bad samples
     {
         return kFALSE;
     }
@@ -63,8 +65,9 @@ Bool_t AraCalType::hasInvertA3Chans(AraCalType::AraCalType_t calType)
 Bool_t AraCalType::hasADCZeroMean(AraCalType::AraCalType_t calType)
 {
     if(calType==kLatestCalibWithOutZeroMean ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
-        || calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction
-        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+        || calType==kOnlyGoodADC            ///< Get the raw ADC WF without bad samples and pedestal subtraction
+        || calType==kOnlyPed                ///< Get the pedestal values for the corresponding raw WF
+        || calType==kOnlyGoodPed)           ///< Get the pedestal values for the corresponding raw WF without bad samples
     {
         return kFALSE;
     }
@@ -80,8 +83,9 @@ Bool_t AraCalType::hasADCZeroMean(AraCalType::AraCalType_t calType)
 Bool_t AraCalType::hasVoltZeroMean(AraCalType::AraCalType_t calType)
 {
     if(calType==kLatestCalibWithOutZeroMean ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
-        || calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction
-        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+        || calType==kOnlyGoodADC            ///< Get the raw ADC WF without bad samples and pedestal subtraction
+        || calType==kOnlyPed                ///< Get the pedestal values for the corresponding raw WF
+        || calType==kOnlyGoodPed)           ///< Get the pedestal values for the corresponding raw WF without bad samples
     {
         return kFALSE;
     }
@@ -93,8 +97,9 @@ Bool_t AraCalType::hasVoltZeroMean(AraCalType::AraCalType_t calType)
 Bool_t AraCalType::hasVoltCal(AraCalType::AraCalType_t calType)
 {
     if(calType==kLatestCalib14to20_Bug
-        || calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
-        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+        || calType==kOnlyGoodADC  ///< Get the raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
+        || calType==kOnlyPed      ///< Get the pedestal values for the corresponding raw WF
+        || calType==kOnlyGoodPed) ///< Get the pedestal values for the corresponding raw WF without bad samples
     {
         return kFALSE;
     }
@@ -133,7 +138,8 @@ Bool_t AraCalType::hasInterleaveCalib(AraCalType::AraCalType_t calType)
 }
 
 Bool_t AraCalType::hasBinWidthCalib(AraCalType::AraCalType_t calType)
-{ 
+{
+    if(calType==kOnlyPed) return kFALSE; ///< Get the pedestal values for the corresponding raw WF, 19-12-2021 -MK- 
     if(calType>=kFirstCalib)
         return kTRUE;
     return kFALSE;
@@ -154,7 +160,7 @@ Bool_t AraCalType::hasClockAlignment(AraCalType::AraCalType_t calType)
 
 Bool_t AraCalType::hasPedestalSubtraction(AraCalType::AraCalType_t calType)
 { 
-    if(calType==kOnlyGoodADC) return kFALSE; ///< Get the only raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
+    if(calType==kOnlyGoodADC) return kFALSE; ///< Get the raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType==kNoCalib) return kFALSE;
     return kTRUE;
 }
@@ -1230,8 +1236,8 @@ void AraEventCalibrator::PedestalSubtraction(UsefulAtriStationEvent *theEvent, s
                     sampleIndex = sampleList->at(chanId)[samp];
                     sampleNumber = sampleIndex%samples_per_block;
                     blockIndex = int(sampleIndex/samples_per_block);
-                    //! Filling with the only pedestal values for the corresponding raw WF, 19-12-2021 -MK-
-                    if(calType==AraCalType::kOnlyGoodPed) { voltMapIt->second[samp] = (Int_t)fAtriPeds[RawAtriStationEvent::getPedIndex(dda,blockIndex,chan,sampleNumber)];
+                    //! Filling with the pedestal values for the corresponding raw WF, 19-12-2021 -MK-
+                    if(calType==AraCalType::kOnlyPed || calType==AraCalType::kOnlyGoodPed) { voltMapIt->second[samp] = (Int_t)fAtriPeds[RawAtriStationEvent::getPedIndex(dda,blockIndex,chan,sampleNumber)];
                     //! Filling with ADC-Pedestal. Iunputted pedestal will be stored in fAtriPeds table
                     } else { voltMapIt->second[samp] -= (Int_t)fAtriPeds[RawAtriStationEvent::getPedIndex(dda,blockIndex,chan,sampleNumber)]; }
                 }

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1933,7 +1933,7 @@ Double_t AraEventCalibrator::convertADCtoMilliVolts(Double_t adcCountsIn, int dd
 
         }
         else {
-            if (station != 5){
+            if (stationId != 5){
                 //! here is the alternative calibration (used only for A2 and A3) if the ADC count exceeds 400
                 if(adcCounts>0) {
                     volts = fAtriSampleHighADCVoltsConversion[dda][chan][block][sample][0] 

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -89,7 +89,8 @@ Bool_t AraCalType::hasCableDelays(AraCalType::AraCalType_t calType)
     if(calType==kFirstCalibPlusCables
         || calType==kSecondCalibPlusCables
         || calType==kSecondCalibPlusCablesUnDiplexed
-        || calType ==kLatestCalib14to20_Bug){
+        || calType ==kLatestCalib14to20_Bug
+        || calType==kLatestCalibWithOutZeroMean){
 
         return kTRUE;
     }
@@ -103,7 +104,8 @@ Bool_t AraCalType::hasInterleaveCalib(AraCalType::AraCalType_t calType)
         || calType==kFirstCalib
         || calType==kSecondCalib
         || calType==kSecondCalibPlusCablesUnDiplexed
-        || calType==kLatestCalib14to20_Bug){
+        || calType==kLatestCalib14to20_Bug
+        || calType==kLatestCalibWithOutZeroMean){
 
         return kTRUE;
     }
@@ -124,7 +126,8 @@ Bool_t AraCalType::hasClockAlignment(AraCalType::AraCalType_t calType)
         || calType==kSecondCalib
         || calType==kSecondCalibPlusCablesUnDiplexed
 
-        || calType==kLatestCalib14to20_Bug){
+        || calType==kLatestCalib14to20_Bug
+        || calType==kLatestCalibWithOutZeroMean){
 
         return kTRUE;
     }
@@ -148,7 +151,8 @@ Bool_t AraCalType::hasCommonMode(AraCalType::AraCalType_t calType)
 Bool_t AraCalType::hasUnDiplexing(AraCalType::AraCalType_t calType)
 {
     if(calType==kSecondCalibPlusCablesUnDiplexed 
-        || calType==kLatestCalib14to20_Bug) return kTRUE;
+        || calType==kLatestCalib14to20_Bug
+        || calType==kLatestCalibWithOutZeroMean) return kTRUE;
 
     return kFALSE;
 }

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -35,7 +35,6 @@
 Bool_t AraCalType::hasTrimFirstBlock(AraCalType::AraCalType_t calType)
 {
     //return kFALSE; ///< Just in case, analyzers want to see 1st block on kLatestCalib
-    if(calType==kJustUnwrap) return kTRUE;  ///< For raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;
 }
@@ -47,6 +46,11 @@ Bool_t AraCalType::hasTrimFirstBlock(AraCalType::AraCalType_t calType)
 */
 Bool_t AraCalType::hasInvertA3Chans(AraCalType::AraCalType_t calType)
 {
+    if(calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
+        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+    {
+        return kFALSE;
+    }
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;
 }
@@ -58,7 +62,12 @@ Bool_t AraCalType::hasInvertA3Chans(AraCalType::AraCalType_t calType)
 */
 Bool_t AraCalType::hasADCZeroMean(AraCalType::AraCalType_t calType)
 {
-    if(calType==kLatestCalibWithOutZeroMean) return kFALSE; ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
+    if(calType==kLatestCalibWithOutZeroMean ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
+        || calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction
+        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+    {
+        return kFALSE;
+    }
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;    
 }
@@ -70,7 +79,12 @@ Bool_t AraCalType::hasADCZeroMean(AraCalType::AraCalType_t calType)
 */
 Bool_t AraCalType::hasVoltZeroMean(AraCalType::AraCalType_t calType)
 {
-    if(calType==kLatestCalibWithOutZeroMean) return kFALSE; ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
+    if(calType==kLatestCalibWithOutZeroMean ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
+        || calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction
+        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+    {
+        return kFALSE;
+    }
     if(calType<kVoltageTime) return kFALSE;
     return kTRUE;
 }
@@ -78,7 +92,12 @@ Bool_t AraCalType::hasVoltZeroMean(AraCalType::AraCalType_t calType)
 //added, 12-Feb 2014 -THM-
 Bool_t AraCalType::hasVoltCal(AraCalType::AraCalType_t calType)
 {
-    if(calType==kLatestCalib14to20_Bug) return kFALSE;
+    if(calType==kLatestCalib14to20_Bug
+        || calType==kOnlyGoodADC ///< Get the only raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
+        || calType==kOnlyGoodPed) ///< Get the only pedestal values for the corresponding raw WF without bad samples
+    {
+        return kFALSE;
+    }
     //return kFALSE; //RJN hackcd .. un-hacked KAH 09152020
     if(calType<kVoltageTime) return kFALSE; ///< Need to be only kFALSE before voltage calibration
     return kTRUE;
@@ -90,7 +109,9 @@ Bool_t AraCalType::hasCableDelays(AraCalType::AraCalType_t calType)
         || calType==kSecondCalibPlusCables
         || calType==kSecondCalibPlusCablesUnDiplexed
         || calType ==kLatestCalib14to20_Bug
-        || calType==kLatestCalibWithOutZeroMean){
+        || calType==kLatestCalibWithOutZeroMean
+        || calType==kOnlyGoodADC
+        || calType==kOnlyGoodPed){
 
         return kTRUE;
     }
@@ -104,8 +125,7 @@ Bool_t AraCalType::hasInterleaveCalib(AraCalType::AraCalType_t calType)
         || calType==kFirstCalib
         || calType==kSecondCalib
         || calType==kSecondCalibPlusCablesUnDiplexed
-        || calType==kLatestCalib14to20_Bug
-        || calType==kLatestCalibWithOutZeroMean){
+        || calType==kLatestCalib14to20_Bug){
 
         return kTRUE;
     }
@@ -114,7 +134,6 @@ Bool_t AraCalType::hasInterleaveCalib(AraCalType::AraCalType_t calType)
 
 Bool_t AraCalType::hasBinWidthCalib(AraCalType::AraCalType_t calType)
 { 
-    if(calType==kJustUnwrap) return kTRUE; ///< For raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType>=kFirstCalib)
         return kTRUE;
     return kFALSE;
@@ -126,8 +145,7 @@ Bool_t AraCalType::hasClockAlignment(AraCalType::AraCalType_t calType)
         || calType==kSecondCalib
         || calType==kSecondCalibPlusCablesUnDiplexed
 
-        || calType==kLatestCalib14to20_Bug
-        || calType==kLatestCalibWithOutZeroMean){
+        || calType==kLatestCalib14to20_Bug){
 
         return kTRUE;
     }
@@ -136,7 +154,7 @@ Bool_t AraCalType::hasClockAlignment(AraCalType::AraCalType_t calType)
 
 Bool_t AraCalType::hasPedestalSubtraction(AraCalType::AraCalType_t calType)
 { 
-    if(calType==kJustUnwrap) return kFALSE; ///< For raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
+    if(calType==kOnlyGoodADC) return kFALSE; ///< Get the only raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType==kNoCalib) return kFALSE;
     return kTRUE;
 }
@@ -151,8 +169,7 @@ Bool_t AraCalType::hasCommonMode(AraCalType::AraCalType_t calType)
 Bool_t AraCalType::hasUnDiplexing(AraCalType::AraCalType_t calType)
 {
     if(calType==kSecondCalibPlusCablesUnDiplexed 
-        || calType==kLatestCalib14to20_Bug
-        || calType==kLatestCalibWithOutZeroMean) return kTRUE;
+        || calType==kLatestCalib14to20_Bug) return kTRUE;
 
     return kFALSE;
 }
@@ -957,13 +974,13 @@ void AraEventCalibrator::calibrateEvent(UsefulAtriStationEvent *theEvent, AraCal
 
     //! 6th step. Timing calibration and bad sample removal
     //! This step calibrates the time of each sample and only selecting the samples that have good performance
-    if(AraCalType::hasBinWidthCalib(calType)){ 
+    if(hasBinWidthCalib(calType)){ 
         hasTimingCalib = TimingCalibrationAndBadSampleReomval(theEvent, voltMapIt, timeMapIt, sampleList, capArrayList, hasTrimFirstBlk);    
     }
     
     //! 7th step. Pedestal subtraction
     if(hasPedestalSubtraction(calType)) {
-        PedestalSubtraction(theEvent, voltMapIt, sampleList);
+        PedestalSubtraction(theEvent, voltMapIt, sampleList, calType);
     }
     
     /*!
@@ -1197,7 +1214,7 @@ Bool_t AraEventCalibrator::TimingCalibrationAndBadSampleReomval(UsefulAtriStatio
     \param voltMapIt the iterator referring to the voltage elements in the 2d map container
     \param sampleList the pointer of WF sample numbers
 */
-void AraEventCalibrator::PedestalSubtraction(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::vector<std::vector<int> > *sampleList)
+void AraEventCalibrator::PedestalSubtraction(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::vector<std::vector<int> > *sampleList, AraCalType::AraCalType_t calType)
 {
 
     int sampleIndex, sampleNumber, blockIndex = 0; ///< capacitor sample index, block sample index, capacitor block index
@@ -1213,8 +1230,10 @@ void AraEventCalibrator::PedestalSubtraction(UsefulAtriStationEvent *theEvent, s
                     sampleIndex = sampleList->at(chanId)[samp];
                     sampleNumber = sampleIndex%samples_per_block;
                     blockIndex = int(sampleIndex/samples_per_block);
-                    ///< Filling with ADC-Pedestal. Iunputted pedestal will be stored in fAtriPeds table
-                    voltMapIt->second[samp] -= (Int_t)fAtriPeds[RawAtriStationEvent::getPedIndex(dda,blockIndex,chan,sampleNumber)];
+                    //! Filling with the only pedestal values for the corresponding raw WF, 19-12-2021 -MK-
+                    if(calType==AraCalType::kOnlyGoodPed) { voltMapIt->second[samp] = (Int_t)fAtriPeds[RawAtriStationEvent::getPedIndex(dda,blockIndex,chan,sampleNumber)];
+                    //! Filling with ADC-Pedestal. Iunputted pedestal will be stored in fAtriPeds table
+                    } else { voltMapIt->second[samp] -= (Int_t)fAtriPeds[RawAtriStationEvent::getPedIndex(dda,blockIndex,chan,sampleNumber)]; }
                 }
             }
         }

--- a/AraEvent/AraEventCalibrator.h
+++ b/AraEvent/AraEventCalibrator.h
@@ -41,7 +41,7 @@ namespace AraCalType {
         kSecondCalibPlusCablesUnDiplexed = 0x09,///< Same as secondCalibPlusCableDelays but with the undiplexing of diplexed channels in ARA_STATION1
 
         kLatestCalib                    = 0x09, ///< Currenly this is kSecondCalibPlusCables
-        kLatestCalib14to20_Bug          = 0x0A ///<new calibration type: everything except voltage calibration. Will reproduce "kLatestCalib" bug present from between ~2014 to September 2020. Use with caution!
+        kLatestCalib14to20_Bug          = 0x0A, ///<new calibration type: everything except voltage calibration. Will reproduce "kLatestCalib" bug present from between ~2014 to September 2020. Use with caution!
         kLatestCalibWithOutZeroMean     = 0x0B ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
 
     } AraCalType_t;

--- a/AraEvent/AraEventCalibrator.h
+++ b/AraEvent/AraEventCalibrator.h
@@ -30,7 +30,7 @@
 namespace AraCalType {
     typedef enum EAraCalType {
         kNoCalib                        = 0x00, ///<The 260 samples straight from raw data
-        kJustUnwrap                     = 0x01, ///<The X good samples from raw data (260-hitbus), Also use this mode for printing out the raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-   
+        kJustUnwrap                     = 0x01, ///<The X good samples from raw data (260-hitbus)   
         kJustPed                        = 0x02, ///<Just subtract peds
         kADC                            = 0x03, ///<Same as kNoCalib -- i.e. useless
         kVoltageTime                    = 0x04, ///<Using 1 and 2.6 
@@ -42,7 +42,11 @@ namespace AraCalType {
 
         kLatestCalib                    = 0x09, ///< Currenly this is kSecondCalibPlusCables
         kLatestCalib14to20_Bug          = 0x0A, ///<new calibration type: everything except voltage calibration. Will reproduce "kLatestCalib" bug present from between ~2014 to September 2020. Use with caution!
-        kLatestCalibWithOutZeroMean     = 0x0B ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
+
+        //! Useful CalType for debugging, 19-12-2021 -MK-
+        kLatestCalibWithOutZeroMean     = 0x0B, ///< Performs every calibration except the ADC and Voltage zero meaning
+        kOnlyGoodPed                    = 0X0C, ///< Get the only pedestal values for the corresponding raw WF without bad samples
+        kOnlyGoodADC                    = 0x0D  ///< Get the only raw ADC WF without bad samples and pedestal subtraction
 
     } AraCalType_t;
 
@@ -138,7 +142,7 @@ class AraEventCalibrator : public TObject
     void UnpackDAQFormatToElecChanFormat(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::map< Int_t, std::vector <Double_t> >::iterator &timeMapIt, std::vector<std::vector<int> > *sampleList, std::vector<std::vector<int> > *capArrayList); ///< Converts DAQ data format to Electronic channel format
     Bool_t TrimFirstBlock(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::map< Int_t, std::vector <Double_t> >::iterator &timeMapIt, std::vector<std::vector<int> > *sampleList, std::vector<std::vector<int> > *capArrayList, Bool_t hasTimingCalib); ///< Erase first block that currupted by trigger
     Bool_t TimingCalibrationAndBadSampleReomval(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::map< Int_t, std::vector <Double_t> >::iterator &timeMapIt, std::vector<std::vector<int> > *sampleList, std::vector<std::vector<int> > *capArrayList, Bool_t hasTrimFirstBlk); ///< Trims samples using fAtriSampleTimes table
-    void PedestalSubtraction(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::vector<std::vector<int> > *sampleList); ///< Subtracts pedestal from raw data
+    void PedestalSubtraction(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::vector<std::vector<int> > *sampleList, AraCalType::AraCalType_t calType); ///< Subtracts pedestal from raw data
     void CommonMode(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt);
     void InvertA3Chans(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, AraStationId_t thisStationId); ///< Inverts only RF channels = 0,4,8 in A3
     void ApplyZeroMean(UsefulAtriStationEvent *theEvent, std::map< Int_t, std::vector <Double_t> >::iterator &voltMapIt, std::vector<std::vector<int> > *capArrayList, Bool_t hasTrimFirstBlk, Bool_t hasTimingCalib); ///< Zeroing WF by subtracting mean. ADC or Voltage. If 1st block is still in the WF, exclude the samplesin the 1st block from mean calculation

--- a/AraEvent/AraEventCalibrator.h
+++ b/AraEvent/AraEventCalibrator.h
@@ -45,8 +45,9 @@ namespace AraCalType {
 
         //! Useful CalType for debugging, 19-12-2021 -MK-
         kLatestCalibWithOutZeroMean     = 0x0B, ///< Performs every calibration except the ADC and Voltage zero meaning
-        kOnlyGoodPed                    = 0X0C, ///< Get the only pedestal values for the corresponding raw WF without bad samples
-        kOnlyGoodADC                    = 0x0D  ///< Get the only raw ADC WF without bad samples and pedestal subtraction
+        kOnlyPed                        = 0X0C, ///< Get the pedestal values for the corresponding raw WF
+        kOnlyGoodPed                    = 0X0D, ///< Get the pedestal values for the corresponding raw WF without bad samples
+        kOnlyGoodADC                    = 0x0E  ///< Get the raw ADC WF without bad samples and pedestal subtraction
 
     } AraCalType_t;
 

--- a/AraEvent/AraEventCalibrator.h
+++ b/AraEvent/AraEventCalibrator.h
@@ -30,7 +30,7 @@
 namespace AraCalType {
     typedef enum EAraCalType {
         kNoCalib                        = 0x00, ///<The 260 samples straight from raw data
-        kJustUnwrap                     = 0x01, ///<The X good samples from raw data (260-hitbus)   
+        kJustUnwrap                     = 0x01, ///<The X good samples from raw data (260-hitbus), Also use this mode for printing out the raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-   
         kJustPed                        = 0x02, ///<Just subtract peds
         kADC                            = 0x03, ///<Same as kNoCalib -- i.e. useless
         kVoltageTime                    = 0x04, ///<Using 1 and 2.6 
@@ -41,7 +41,8 @@ namespace AraCalType {
         kSecondCalibPlusCablesUnDiplexed = 0x09,///< Same as secondCalibPlusCableDelays but with the undiplexing of diplexed channels in ARA_STATION1
 
         kLatestCalib                    = 0x09, ///< Currenly this is kSecondCalibPlusCables
-        kLatestCalib14to20_Bug                = 0x0A //new calibration type: everything except voltage calibration. Will reproduce "kLatestCalib" bug present from between ~2014 to September 2020. Use with caution!
+        kLatestCalib14to20_Bug          = 0x0A ///<new calibration type: everything except voltage calibration. Will reproduce "kLatestCalib" bug present from between ~2014 to September 2020. Use with caution!
+        kLatestCalibWithOutZeroMean     = 0x0B ///< Performs every calibration except the ADC and Voltage zero meaning, 19-12-2021 -MK-
 
     } AraCalType_t;
 


### PR DESCRIPTION
**1. kLatestCalibWithOutZeroMean**

Performs every calibration except the ADC and Voltage zero meaning. 
Since the zero meaning function is an additional correction for calibration, I added the mode to turn off the correction.
By this mode, the user can check how much offset that WF can have from 0 after pedestal subtraction.

**2. kOnlyGoodADC** 

Apply only time calibration to WF
It will print out the raw ADC WF without bad samples and pedestal subtraction.
If the user chooses this mode to calibrate the WF, It turn on only `TrimFirstBlock()`, `TimingCalibrationAndBadSampleReomval()` and `ApplyCableDelay()`.
So, users can check the only good raw ADC samples.

**3. kOnlyGoodPed**

Since there is no method to check what is the pedestal values for the corresponding WF through AraRoot, I implemented this method. So, users can easily get pedestal values by AraRoot
If the user chooses this mode, `PedestalSubtraction()` will fill up `voltMapIt` iterator with pedestal values and It turn on only `PedestalSubtraction()`, `TrimFirstBlock()`, `TimingCalibrationAndBadSampleReomval()` and `ApplyCableDelay()` for good pededstal samples.

**4. kOnlyPed**

Same as **kOnlyGoodPed**. But this mode is not applying time calibration. 
It will print out 'all' pedestal values for the corresponding WF.