### PR TITLE
Adding new AraCalType v3

### DIFF
--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -95,7 +95,8 @@ Bool_t AraCalType::hasCableDelays(AraCalType::AraCalType_t calType)
         || calType==kLatestCalib14to20_Bug
         || calType==kLatestCalibWithOutZeroMean
         || calType==kOnlyPedWithOut1stBlockAndBadSamples
-        || calType==kOnlyADCWithOut1stBlockAndBadSamples){
+        || calType==kOnlyADCWithOut1stBlockAndBadSamples
+        || calType==kJustPedWithOut1stBlockAndBadSamples){
 
         return kTRUE;
     }
@@ -121,7 +122,8 @@ Bool_t AraCalType::hasBinWidthCalib(AraCalType::AraCalType_t calType)
     if(calType==kOnlyPed
         || calType==kOnlyPedWithOut1stBlock
         || calType==kOnlyADC
-        || calType==kOnlyADCWithOut1stBlock) return kFALSE;
+        || calType==kOnlyADCWithOut1stBlock
+        || calType==kJustPedWithOut1stBlock) return kFALSE;
     if(calType>=kFirstCalib)
         return kTRUE;
     return kFALSE;
@@ -142,6 +144,8 @@ Bool_t AraCalType::hasClockAlignment(AraCalType::AraCalType_t calType)
 
 Bool_t AraCalType::hasPedestalSubtraction(AraCalType::AraCalType_t calType)
 { 
+    if(calType==kJustPedWithOut1stBlock
+        || calType==kJustPedWithOut1stBlockAndBadSamples) return kTRUE;
     if(calType>kOnlyPedWithOut1stBlockAndBadSamples) return kFALSE; ///< Get the raw ADC WF without bad samples and pedestal subtraction, 19-12-2021 -MK-
     if(calType==kNoCalib) return kFALSE;
     return kTRUE;

--- a/AraEvent/AraEventCalibrator.h
+++ b/AraEvent/AraEventCalibrator.h
@@ -59,7 +59,9 @@ namespace AraCalType {
         kOnlyPedWithOut1stBlockAndBadSamples = 0x0E,
         kOnlyADC                             = 0x0F, ///< Same as kNoCalib
         kOnlyADCWithOut1stBlock              = 0x10,
-        kOnlyADCWithOut1stBlockAndBadSamples = 0x11
+        kOnlyADCWithOut1stBlockAndBadSamples = 0x11,
+        kJustPedWithOut1stBlock              = 0x12, ///< subtract peds and remove first block , 05-03-2022 -MK-
+        kJustPedWithOut1stBlockAndBadSamples = 0x13 ///< subtract peds and remove first block and bad sampeles. useful for checking the wf that has large offet from ped
 
     } AraCalType_t;
 


### PR DESCRIPTION
To identify offset from 0 after pedestal subtraction, I added two more calibration type

1) **kJustPedWithOut1stBlock**
It will perform only `PedestalSubtraction()` and `TrimFirstBlock()`

2) **kJustPedWithOut1stBlockAndBadSamples**
It will perform only `PedestalSubtraction()`, `TrimFirstBlock()`,` TimingCalibrationAndBadSampleReomval()` and `ApplyCableDelay()`
The number of samples and time width betweens samples will be the same as fully calibrated WF (kLatestCalib). So, users can easily to compare the result with calibrated WF.