### PR TITLE
Martin01021207 patch 1

### DIFF
--- a/AraEvent/AraQualCuts.cxx
+++ b/AraEvent/AraQualCuts.cxx
@@ -346,6 +346,33 @@ bool AraQualCuts::hasTooFewBlocks(UsefulAtriStationEvent *realEvent)
     return hasTooFewBlocks;
 }
 
+//! Returns if a real atri event contains a waveform whose number of samples is less than 500.
+/*!
+    \param realEvent the useful atri event pointer
+    \return if the event contains a waveform that has too few samples (<500) to be analyzed
+*/
+bool AraQualCuts::hasTooFewSamples(UsefulAtriStationEvent *realEvent)
+{
+
+    /*
+        In an analyzable waveform, the number of samples should be greater than 500.
+        If not, we shouldn't analyze this event
+    */
+
+    const int numSampThreshold = 500; 
+    bool hasTooFewSamples=false;
+    for(int chan=0; chan<realEvent->getNumRFChannels(); chan++){
+        TGraph* gr = realEvent->getGraphFromRFChan(chan); //get the waveform
+        int N = gr->GetN();
+        delete gr;
+        if(N<numSampThreshold){
+            hasTooFewSamples=true;
+            break;
+        }
+    }
+    return hasTooFewSamples;
+}
+
 //! Returns if a real atri event has first event corruption issues
 /*!
     \param rawEvent the raw atri event pointer

--- a/AraEvent/AraQualCuts.cxx
+++ b/AraEvent/AraQualCuts.cxx
@@ -61,8 +61,9 @@ bool AraQualCuts::isGoodEvent(UsefulAtriStationEvent *realEvent)
     bool this_hasBlockGap = hasBlockGap(realEvent);
     bool this_hasTimingError = hasTimingError(realEvent);
     bool this_hasTooFewBlocks = hasTooFewBlocks(realEvent);
+    bool this_hasTooFewSamples = hasTooFewSamples(realEvent);
     bool this_hasOffsetBlocks = false;
-    if(!this_hasBlockGap && !this_hasTimingError && !this_hasTooFewBlocks){
+    if(!this_hasBlockGap && !this_hasTimingError && !this_hasTooFewBlocks && !this_hasTooFewSamples){
         this_hasOffsetBlocks = hasOffsetBlocks(realEvent);
     }
     
@@ -70,7 +71,8 @@ bool AraQualCuts::isGoodEvent(UsefulAtriStationEvent *realEvent)
 
     if(this_hasBlockGap 
         || this_hasTimingError 
-        || this_hasTooFewBlocks 
+        || this_hasTooFewBlocks
+        || this_hasTooFewSamples
         || this_hasOffsetBlocks
         || this_hasFirstEventCorruption){
         isGoodEvent=false;

--- a/AraEvent/AraQualCuts.h
+++ b/AraEvent/AraQualCuts.h
@@ -31,6 +31,7 @@ class AraQualCuts
         bool hasBlockGap(RawAtriStationEvent *rawEvent); ///< Detects block gaps
         bool hasTimingError(UsefulAtriStationEvent *realEvent); ///< Detects timing errors
         bool hasTooFewBlocks(UsefulAtriStationEvent *realEvent); ///< Detects too few block cases
+        bool hasTooFewSamples(UsefulAtriStationEvent *realEvent); ///< Detects too few waveform samples
         bool hasFirstEventCorruption(RawAtriStationEvent *rawEvent); ///<Checks for event corruption in A2 and A3
 
         /*


### PR DESCRIPTION
#40 Update AraQualCuts short waveform criteria

A function named `hasTooFewSamples()` was added in both files **AraQualCuts.cxx** and **AraQualCuts.h**, this function detects waveforms whose number of samples is less than 500 (too few samples).