### PR TITLE
Addition of Getter function for arrival times in the RayTraceCorrelator

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -313,6 +313,14 @@ void RayTraceCorrelator::LookupArrivalAngles(
     arrivalPhi = this->arrivalPhis_[solNum][thetaBin][phiBin][ant];
 }
 
+void RayTraceCorrelator::LookupArrivalTimes(
+    int ant, int solNum,
+    int thetaBin, int phiBin,
+    double &arrivalTime
+){
+    arrivalTime = this->arrivalTimes_[solNum][thetaBin][phiBin][ant];
+}
+
 
 TH2D* RayTraceCorrelator::GetInterferometricMap(
     std::map<int, std::vector<int> > pairs,
@@ -369,8 +377,10 @@ TH2D* RayTraceCorrelator::GetInterferometricMap(
             for(int thetaBin=0; thetaBin < this->numThetaBins_; thetaBin++){
                 
                 int globalBin = (phiBin + 1) + (thetaBin + 1) * (this->numPhiBins_ + 2);
-                double arrival_time1 = this->arrivalTimes_[solNum][thetaBin][phiBin][ant1];
-                double arrival_time2 = this->arrivalTimes_[solNum][thetaBin][phiBin][ant2];
+                double arrival_time1;
+                double arrival_time2;
+                LookupArrivalTimes(ant1, solNum, thetaBin, phiBin, arrival_time1);
+                LookupArrivalTimes(ant2, solNum, thetaBin, phiBin, arrival_time2);
                 double dt = arrival_time1 - arrival_time2;
 
                 // sanity check

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -116,6 +116,12 @@ class RayTraceCorrelator : public TObject
             int thetaBin, int phiBin,
             double &arrivalTheta, double &arrivalPhi
         );
+        
+        void LookupArrivalTimes(
+            int ant, int solNum,
+            int thetaBin, int phiBin,
+            double &arrivalTime
+        );        
 
         //! function to get lookup the bin numbers of a source hypothesis direction
         /*!


### PR DESCRIPTION
Created getter function for arrival times called LookupArrivalTimes(), which simply allows access to the private variable arrivalTimes_.  For consistency, I also updated a step in the correlator where it looks up the arrival times using the private variable to now use the getter function.