### PR TITLE
Added support for launch angles of RF signal from source.

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -112,20 +112,28 @@ void RayTraceCorrelator::ConfigureArrivalVectors(){
     arrivalTimes_.resize(2);
     arrivalThetas_.resize(2);
     arrivalPhis_.resize(2);
+    launchThetas_.resize(2);
+    launchPhis_.resize(2);    
     for(int sol=0; sol<2; sol++){
         arrivalTimes_[sol].resize(numThetaBins_);
         arrivalThetas_[sol].resize(numThetaBins_);
         arrivalPhis_[sol].resize(numThetaBins_);
+        launchThetas_[sol].resize(numThetaBins_);
+        launchPhis_[sol].resize(numThetaBins_);        
         for(int thetaBin=0; thetaBin<numThetaBins_; thetaBin++){
             arrivalTimes_[sol][thetaBin].resize(numPhiBins_);
             arrivalThetas_[sol][thetaBin].resize(numPhiBins_);
             arrivalPhis_[sol][thetaBin].resize(numPhiBins_);
+            launchThetas_[sol][thetaBin].resize(numPhiBins_);
+            launchPhis_[sol][thetaBin].resize(numPhiBins_);            
         }
         for(int thetaBin=0; thetaBin<numThetaBins_; thetaBin++){
             for(int phiBin=0; phiBin<numPhiBins_; phiBin++){
                 arrivalTimes_[sol][thetaBin][phiBin].resize(numAntennas_);
                 arrivalThetas_[sol][thetaBin][phiBin].resize(numAntennas_);
                 arrivalPhis_[sol][thetaBin][phiBin].resize(numAntennas_);
+                launchThetas_[sol][thetaBin][phiBin].resize(numAntennas_);
+                launchPhis_[sol][thetaBin][phiBin].resize(numAntennas_);                
             }
         }
     }
@@ -152,13 +160,15 @@ void RayTraceCorrelator::LoadArrivalTimeTables(const std::string &filename, int 
     // if the file is good, load the variables from the branches
     int ant, phiBin, thetaBin;
     double phi, theta;
-    double arrivalTime, arrivalTheta, arrivalPhi;
+    double arrivalTime, arrivalTheta, arrivalPhi, launchTheta, launchPhi;
     tTree -> SetBranchAddress("ant", & ant);
     tTree -> SetBranchAddress("phiBin", & phiBin);
     tTree -> SetBranchAddress("thetaBin", & thetaBin);
     tTree -> SetBranchAddress("arrivalTime", & arrivalTime);
     tTree -> SetBranchAddress("arrivalTheta", & arrivalTheta);
     tTree -> SetBranchAddress("arrivalPhi", & arrivalPhi);
+    tTree -> SetBranchAddress("launchTheta", & launchTheta);
+    tTree -> SetBranchAddress("launchPhi", & launchPhi);    
     tTree -> SetBranchAddress("phi", & phi);
     tTree -> SetBranchAddress("theta", & theta);
 
@@ -169,6 +179,8 @@ void RayTraceCorrelator::LoadArrivalTimeTables(const std::string &filename, int 
         arrivalTimes_[solNum][thetaBin][phiBin][ant] = arrivalTime;
         arrivalThetas_[solNum][thetaBin][phiBin][ant] = arrivalTheta;
         arrivalPhis_[solNum][thetaBin][phiBin][ant] = arrivalPhi;
+        launchThetas_[solNum][thetaBin][phiBin][ant] = launchTheta;
+        launchPhis_[solNum][thetaBin][phiBin][ant] = launchPhi;        
     }
 
     // close up
@@ -311,6 +323,15 @@ void RayTraceCorrelator::LookupArrivalAngles(
 ){
     arrivalTheta = this->arrivalThetas_[solNum][thetaBin][phiBin][ant];
     arrivalPhi = this->arrivalPhis_[solNum][thetaBin][phiBin][ant];
+}
+
+void RayTraceCorrelator::LookupLaunchAngles(
+    int ant, int solNum,
+    int thetaBin, int phiBin,
+    double &launchTheta, double &launchPhi
+){
+    launchTheta = this->launchThetas_[solNum][thetaBin][phiBin][ant];
+    launchPhi = this->launchPhis_[solNum][thetaBin][phiBin][ant];
 }
 
 double RayTraceCorrelator::LookupArrivalTimes(

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -40,6 +40,8 @@ class RayTraceCorrelator : public TObject
         // same dimensions and explanations, just for theta and phi
         std::vector < std::vector < std::vector < std::vector < double > > > > arrivalThetas_;
         std::vector < std::vector < std::vector < std::vector < double > > > > arrivalPhis_;
+        std::vector < std::vector < std::vector < std::vector < double > > > > launchThetas_;
+        std::vector < std::vector < std::vector < std::vector < double > > > > launchPhis_;        
 
         
         void ConfigureArrivalVectors(); ///< Function to set the dimensions of arrivalTimes_, arrivalThetas_, etc. correctly
@@ -116,6 +118,22 @@ class RayTraceCorrelator : public TObject
             int thetaBin, int phiBin,
             double &arrivalTheta, double &arrivalPhi
         );
+        
+        //! function to get lookup the launch angle information
+        /*!
+            \param ant antenna index
+            \param solNum which solution number (0 = direct, 1 = reflected/refracted)
+            \param thetaBin the theta bin desired (bin space, not angle space!!)
+            \param phiBin the phi bin desired (bin space, not angle space!!)
+            \param launchTheta passed by reference, content is replaced with the launch theta angle (in a coordinate where z-axis is along the Earth's radius)
+            \param launchPhi passed by reference, content is replaced with the launch phi angle (in a coordinate where z-axis is along the Earth's radius)
+            \return void
+        */
+        void LookupLaunchAngles(
+            int ant, int solNum,
+            int thetaBin, int phiBin,
+            double &launchTheta, double &launchPhi
+        );        
         
         
         //! function to get lookup the arrival time information

--- a/AraCorrelator/RayTraceCorrelator_support/make_timing_tables/makeRTArrivalTimeTables.cpp
+++ b/AraCorrelator/RayTraceCorrelator_support/make_timing_tables/makeRTArrivalTimeTables.cpp
@@ -126,7 +126,6 @@ void CalculateTables(RayTraceCorrelator *theCorrelator, int solNum, int iceModel
     settings->Z_TOLERANCE = 0.05;
     
     settings->NOFZ=1; // make sure n(z) is turned on
-    // settings->NOFZ=0; // debugging
     settings->RAY_TRACE_ICE_MODEL_PARAMS = iceModelidx; // set the ice model as user requested
 
     for (int thetaBin_temp = 0; thetaBin_temp < numThetaBins; thetaBin_temp++) {


### PR DESCRIPTION
Added calculation and output of the launch angles of the RF signal from a source vertex.  The Ray Tracer natively calculated the receiving and launch angles with respect to the position vector of the receiver antenna (referred to as **_target_** in the code).  A diagram of the vector geometry can be seen in the image below:
![image](https://github.com/ara-software/AraRoot/assets/50030609/d89a2819-1fdf-4176-9339-f5549c39aeb1)
where **_target_** is the position vector of the receiver antenna relative to the center of the Earth, **_source_** is the position vector of the source vertex relative to the center of the Earth.  As implied by the names, _**launchVector**_ and _**receiveVector**_ are the trajectories of the RF signal at the source and receiver, respectively.  Within the Ray Tracer, there are values for _**launchAngle**_ and **_receiptAngle_**, which are measured with respect the the _**target**_ vector as shown in the figure.

The ray tracing table script uses the _**receiveVector**_ to calculate _**arrivalTheta**_ and **_arrivalPhi_** of the RF trajectory with the z-axis along the Earth's radius and stores those values in the ray tracing tables.  This push uses that same logic to calculate the **_launchTheta_** and **_launchPhi_** of the launch vector and store them into the ray tracing tables.