### PR TITLE
Update the correlation routine in the RayTraceCorrelator

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -299,12 +299,12 @@ std::vector<TGraph*> RayTraceCorrelator::GetCorrFunctions(
 
         // It's a bit inefficient to reget the normalized traces every time,
         // and not push this into the waveform getter. But shouldn't be a huge waste.
-        auto temp1 = getNormalisedGraphByRMS(gr1_iter->second);
-        auto temp2 = getNormalisedGraphByRMS(gr2_iter->second);
+        auto graph1_normed = getNormalisedGraphByRMS(gr1_iter->second);
+        auto graph2_normed = getNormalisedGraphByRMS(gr2_iter->second);
 
         // get the correlation graph
-        TGraph *grCorr = FFTtools::getCorrelationGraph(temp1, temp2);
-        delete temp1, temp2;
+        TGraph *grCorr = FFTtools::getCorrelationGraph(graph1_normed, graph2_normed);
+        delete graph1_normed, graph2_normed;
 
         // store the correlation function, with a hilbert envelope applied (if requested)
         if(applyHilbertEnvelope){

--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -299,8 +299,8 @@ std::vector<TGraph*> RayTraceCorrelator::GetCorrFunctions(
 
         // It's a bit inefficient to reget the normalized traces every time,
         // and not push this into the waveform getter. But shouldn't be a huge waste.
-        auto temp1 = getNormalisedGraph(gr1_iter->second);
-        auto temp2 = getNormalisedGraph(gr2_iter->second);
+        auto temp1 = getNormalisedGraphByRMS(gr1_iter->second);
+        auto temp2 = getNormalisedGraphByRMS(gr2_iter->second);
 
         // get the correlation graph
         TGraph *grCorr = FFTtools::getCorrelationGraph(temp1, temp2);

--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -297,11 +297,14 @@ std::vector<TGraph*> RayTraceCorrelator::GetCorrFunctions(
             throw std::invalid_argument(errorMessage);
         }
 
-        // get the correlation function
-        TGraph *grCorr = getCorrelationGraph_WFweight(
-            gr1_iter->second, 
-            gr2_iter->second
-            );
+        // It's a bit inefficient to reget the normalized traces every time,
+        // and not push this into the waveform getter. But shouldn't be a huge waste.
+        auto temp1 = getNormalisedGraph(gr1_iter->second);
+        auto temp2 = getNormalisedGraph(gr2_iter->second);
+
+        // get the correlation graph
+        TGraph *grCorr = FFTtools::getCorrelationGraph(temp1, temp2);
+        delete temp1, temp2;
 
         // store the correlation function, with a hilbert envelope applied (if requested)
         if(applyHilbertEnvelope){

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -237,7 +237,7 @@ class RayTraceCorrelator : public TObject
             \param grIn the graph to be normalized
             \return TGraph* the normalized graph (a new object)
         */
-        TGraph* getNormalisedGraph(TGraph* grIn);
+        TGraph* getNormalisedGraphByRMS(TGraph* grIn);
 
 
 

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -231,6 +231,16 @@ class RayTraceCorrelator : public TObject
         */
         double fastEvalForEvenSampling(TGraph* grIn, double xvalue);
 
+
+        //! a function to normalize a waveform by it's RMS
+        /*!
+            \param grIn the graph to be normalized
+            \return TGraph* the normalized graph (a new object)
+        */
+        TGraph* getNormalisedGraph(TGraph* grIn);
+
+
+
     ClassDef(RayTraceCorrelator,0);
 
 };

--- a/AraCorrelator/RayTraceCorrelator_detail.h
+++ b/AraCorrelator/RayTraceCorrelator_detail.h
@@ -16,7 +16,7 @@ double RayTraceCorrelator::fastEvalForEvenSampling(TGraph * grIn, double xvalue)
     return FFTtools::simpleInterploate(xVals[p0], yVals[p0], xVals[p0 + 1], yVals[p0 + 1], xvalue);
 }
 
-TGraph* RayTraceCorrelator::getNormalisedGraph(TGraph *grIn){
+TGraph* RayTraceCorrelator::getNormalisedGraphByRMS(TGraph *grIn){
     Double_t rms=grIn->GetRMS(2);
     Double_t *xVals = grIn->GetX();
     Double_t *yVals = grIn->GetY();

--- a/AraCorrelator/RayTraceCorrelator_detail.h
+++ b/AraCorrelator/RayTraceCorrelator_detail.h
@@ -16,6 +16,20 @@ double RayTraceCorrelator::fastEvalForEvenSampling(TGraph * grIn, double xvalue)
     return FFTtools::simpleInterploate(xVals[p0], yVals[p0], xVals[p0 + 1], yVals[p0 + 1], xvalue);
 }
 
+TGraph* RayTraceCorrelator::getNormalisedGraph(TGraph *grIn){
+    Double_t rms=grIn->GetRMS(2);
+    Double_t *xVals = grIn->GetX();
+    Double_t *yVals = grIn->GetY();
+    Int_t numPoints = grIn->GetN();
+    Double_t *newY = new Double_t [numPoints];
+    for(int i=0;i<numPoints;i++) {
+        newY[i]=(yVals[i])/rms;
+    }
+    TGraph *grOut = new TGraph(numPoints,xVals,newY);
+    delete [] newY;
+    return grOut;    
+}
+
 double* RayTraceCorrelator::getCorrelation_NoNorm(int length, double * oldY1, double * oldY2) {
 
     FFTWComplex * theFFT1 = FFTtools::doFFT(length, oldY1);


### PR DESCRIPTION
This PR changes the correlation routine called by default in the RayTraceCorrelator. The previous one, which tried to account for trace lengths, is just a little to slow for standard multipurpose use. This one is a couple orders of magnitude faster. It takes about 10 milliseconds to make the vpol and hpol cross-corr functions, while the previous algorithm took about 5 seconds (both when called from pyroot).

To do this, I also had to introduce a function to normalize the waveforms by their RMS before they enter the correlator.