### PR TITLE
make update to the RTC

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -264,7 +264,7 @@ std::map< int, std::vector<int> > RayTraceCorrelator::SetupPairs(
     return pairs;
 }
 
-std::vector<TGraph*> RayTraceCorrelator::GetCorrFunctions(
+std::vector<TGraph> RayTraceCorrelator::GetCorrFunctions(
     std::map<int, std::vector<int> > pairs,
     std::map<int, TGraph*> interpolatedWaveforms,
     bool applyHilbertEnvelope
@@ -275,7 +275,7 @@ std::vector<TGraph*> RayTraceCorrelator::GetCorrFunctions(
     // first, calculate all of the correlation functions
     // for performance reasons, it's actually better to store
     // the correlation functions as a vector
-    std::vector<TGraph*> corrFunctions;
+    std::vector<TGraph> corrFunctions;
     for(auto iter = pairs.begin(); iter != pairs.end(); ++iter){
         int pairNum = iter->first;
         int ant1 = iter->second[0];
@@ -303,17 +303,41 @@ std::vector<TGraph*> RayTraceCorrelator::GetCorrFunctions(
         auto graph2_normed = getNormalisedGraphByRMS(gr2_iter->second);
 
         // get the correlation graph
-        TGraph *grCorr = FFTtools::getCorrelationGraph(graph1_normed, graph2_normed);
-        delete graph1_normed, graph2_normed;
+        std::unique_ptr<TGraph> grCorr{FFTtools::getCorrelationGraph(graph1_normed.get(), graph2_normed.get())};
 
         // store the correlation function, with a hilbert envelope applied (if requested)
         if(applyHilbertEnvelope){
-            TGraph *grCorrHil = FFTtools::getHilbertEnvelope(grCorr);
-            corrFunctions.push_back(grCorrHil);
-            delete grCorr;
+            std::unique_ptr<TGraph> grCorrHil{FFTtools::getHilbertEnvelope(grCorr.get())};
+
+            // drop this into a non-pointered object
+            std::vector<double> tVals;
+            std::vector<double> vVals;
+            double *xvals = grCorrHil->GetX();
+            double *yvals = grCorrHil->GetY();
+            int nPoints = grCorrHil->GetN();
+            for (int isamp=0; isamp<nPoints; isamp++){
+                tVals.push_back(xvals[isamp]);
+                vVals.push_back(yvals[isamp]);
+            }
+            TGraph grCorrHilOut(nPoints, &tVals[0], &vVals[0]);
+            
+            corrFunctions.push_back(grCorrHilOut);
         }
         else{
-            corrFunctions.push_back(grCorr);
+            
+            // drop this into a non-pointered object
+            std::vector<double> tVals;
+            std::vector<double> vVals;
+            double *xvals = grCorr->GetX();
+            double *yvals = grCorr->GetY();
+            int nPoints = grCorr->GetN();
+            for (int isamp=0; isamp<nPoints; isamp++){
+                tVals.push_back(xvals[isamp]);
+                vVals.push_back(yvals[isamp]);
+            }
+            TGraph grCorrOut(nPoints, &tVals[0], &vVals[0]);
+            
+            corrFunctions.push_back(grCorrOut);
         }
     }
     return corrFunctions;
@@ -345,9 +369,9 @@ double RayTraceCorrelator::LookupArrivalTimes(
 }
 
 
-TH2D* RayTraceCorrelator::GetInterferometricMap(
+TH2D RayTraceCorrelator::GetInterferometricMap(
     std::map<int, std::vector<int> > pairs,
-    std::vector<TGraph*> corrFunctions,
+    std::vector<TGraph> corrFunctions,
     int solNum,
     std::map<int, double> weights
     ){
@@ -376,11 +400,7 @@ TH2D* RayTraceCorrelator::GetInterferometricMap(
         throw std::invalid_argument(errorMessage);
     }
 
-    // create output histogram
-    TH2D *histMap = new TH2D("", "", 
-        this->numPhiBins_, -180, 180, 
-        this->numThetaBins_, -90, 90
-    );
+    TH2D histMap("", "", this->numPhiBins_, -180, 180, this->numThetaBins_, -90, 90);
 
     // now, make the map
     for(auto iter = pairs.begin(); iter != pairs.end(); ++iter){
@@ -396,6 +416,21 @@ TH2D* RayTraceCorrelator::GetInterferometricMap(
         }
         double scale = weight_iter->second;
 
+        // for performance reasons, we do the correlation right here
+        // so we draw out the x and y values of the correlation function to be used later
+        int numPoints = corrFunctions[pairNum].GetN();
+        if (numPoints < 2){
+            sprintf(errorMessage,"Number of points in the corr function %d is not valid\n",pairNum);
+            throw std::invalid_argument(errorMessage);
+        }
+        auto xVals = corrFunctions[pairNum].GetX();
+        auto yVals = corrFunctions[pairNum].GetY();
+        double dx = xVals[1] - xVals[0];
+        if (dx <= 0){
+            sprintf(errorMessage,"dx of the correlation function %f is not valid\n",pairNum);
+            throw std::invalid_argument(errorMessage);
+        }
+
         for(int phiBin=0; phiBin < this->numPhiBins_; phiBin++){
             for(int thetaBin=0; thetaBin < this->numThetaBins_; thetaBin++){
                 
@@ -405,15 +440,27 @@ TH2D* RayTraceCorrelator::GetInterferometricMap(
                 double dt = arrival_time1 - arrival_time2;
 
                 // sanity check
-                if (arrival_time1 < -100 || arrival_time2 < -100 || histMap -> GetBinContent(globalBin) == -1000) {
-                    histMap -> SetBinContent(globalBin, -1000);
+                if (arrival_time1 < -100 || arrival_time2 < -100 || histMap.GetBinContent(globalBin) == -1000) {
+                    histMap.SetBinContent(globalBin, -1000);
                 }
                 else{
-                    double corrVal = fastEvalForEvenSampling(corrFunctions[pairNum], dt);
+
+                    // work out the index we want
+                    int p0 = int((dt - xVals[0]) / dx);
+                    if (p0 < 0) p0 = 0;
+                    if (p0 >= numPoints) p0 = numPoints - 2;
+
+                    // and do a simple linear interpolation
+                    // which has the form (y2 - y1)* ((x - x1) / (x2-x1)) + y1
+                    // double corrVal = (yVals[p0 + 1] - yVals[p0]) * ((dt - xVals[p0]) / (xVals[p0 + 1]-xVals[p0])) + yVals[p0];
+                    // actually, FFTtools can do it for us, seemingly without a major hit in performance
+                    // (the compiler might be pulling that in behind the scenes, the function is so simple...)
+                    double corrVal = FFTtools::simpleInterploate(xVals[p0], yVals[p0], xVals[p0 + 1], yVals[p0 + 1], dt);
+
                     corrVal *= scale;
-                    double binVal = histMap -> GetBinContent(globalBin);
+                    double binVal = histMap.GetBinContent(globalBin);
                     if (corrVal == corrVal){ // not a nan
-                        histMap -> SetBinContent(globalBin, binVal + corrVal);
+                        histMap.SetBinContent(globalBin, binVal + corrVal);
                     }
                 }
             }
@@ -424,8 +471,8 @@ TH2D* RayTraceCorrelator::GetInterferometricMap(
     for (int phiBin = 0; phiBin < this->numPhiBins_; phiBin++) {
         for (int thetaBin = 0; thetaBin < this->numThetaBins_; thetaBin++) {
             Int_t globalBin = (phiBin + 1) + (thetaBin + 1) * (this->numPhiBins_ + 2);
-            if (histMap -> GetBinContent(globalBin) == -1000) {
-                histMap -> SetBinContent(globalBin, 0);
+            if (histMap.GetBinContent(globalBin) == -1000) {
+                histMap.SetBinContent(globalBin, 0);
             }
         }
     }

--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -310,6 +310,7 @@ std::vector<TGraph> RayTraceCorrelator::GetCorrFunctions(
             std::unique_ptr<TGraph> grCorrHil{FFTtools::getHilbertEnvelope(grCorr.get())};
 
             // drop this into a non-pointered object
+            // unique pointer will clean up grCorrHil for us!
             std::vector<double> tVals;
             std::vector<double> vVals;
             double *xvals = grCorrHil->GetX();
@@ -326,6 +327,7 @@ std::vector<TGraph> RayTraceCorrelator::GetCorrFunctions(
         else{
             
             // drop this into a non-pointered object
+            // unique pointer will clean up grCorr for us
             std::vector<double> tVals;
             std::vector<double> vVals;
             double *xvals = grCorr->GetX();

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -2,6 +2,7 @@
 #define RAYTRACECORRELATOR_H
 
 #include <map>
+#include <memory>
 class TGraph;
 class TH2D;
 class AraGeomTool;
@@ -96,7 +97,7 @@ class RayTraceCorrelator : public TObject
             \param applyHilbertEnvelope whether or not to apply hilbert enveloping to the correlation functions
             \return a std::vector of the correlation functions (one for each pair)
         */
-        std::vector<TGraph*> GetCorrFunctions(
+        std::vector<TGraph> GetCorrFunctions(
             std::map<int, std::vector<int> > pairs,
             std::map<int, TGraph*> interpolatedWaveforms,
             bool applyHilbertEnvelope = true
@@ -171,9 +172,9 @@ class RayTraceCorrelator : public TObject
             \param weights weights to apply to each map; default = equal weights, or 1/pairs.size()
             \return a 2D histogram with the values filled with the interferometric sums
         */
-        TH2D* GetInterferometricMap(
+        TH2D GetInterferometricMap(
             std::map<int, std::vector<int> > pairs,
-            std::vector<TGraph*> corrFunctions,
+            std::vector<TGraph> corrFunctions,
             int solNum,
             std::map<int, double> weights = {}
         );
@@ -223,22 +224,12 @@ class RayTraceCorrelator : public TObject
         double * getCorrelation_NoNorm(int length, double * oldY1, double * oldY2);
 
 
-        //! a function to get the linearly interpolated value of a function at a time
-        /*!
-            \param grIn the TGraph to be evaluated
-            \param xvalue the point at which to get the interpolated value
-            \return the interpolated value of grIn at point xalue
-        */
-        double fastEvalForEvenSampling(TGraph* grIn, double xvalue);
-
-
         //! a function to normalize a waveform by it's RMS
         /*!
             \param grIn the graph to be normalized
             \return TGraph* the normalized graph (a new object)
         */
-        TGraph* getNormalisedGraphByRMS(TGraph* grIn);
-
+        std::unique_ptr<TGraph> getNormalisedGraphByRMS(TGraph *grIn);
 
 
     ClassDef(RayTraceCorrelator,0);

--- a/AraCorrelator/RayTraceCorrelator_detail.h
+++ b/AraCorrelator/RayTraceCorrelator_detail.h
@@ -2,21 +2,8 @@
 #include "RayTraceCorrelator.h"
 #include "FFTtools.h"
 
-double RayTraceCorrelator::fastEvalForEvenSampling(TGraph * grIn, double xvalue) {
-    Int_t numPoints = grIn -> GetN();
-    if (numPoints < 2) return 0;
-    Double_t * xVals = grIn -> GetX();
-    Double_t * yVals = grIn -> GetY();
-    Double_t dx = xVals[1] - xVals[0];
-    if (dx <= 0) return 0;
 
-    Int_t p0 = Int_t((xvalue - xVals[0]) / dx);
-    if (p0 < 0) p0 = 0;
-    if (p0 >= numPoints) p0 = numPoints - 2;
-    return FFTtools::simpleInterploate(xVals[p0], yVals[p0], xVals[p0 + 1], yVals[p0 + 1], xvalue);
-}
-
-TGraph* RayTraceCorrelator::getNormalisedGraphByRMS(TGraph *grIn){
+std::unique_ptr<TGraph> RayTraceCorrelator::getNormalisedGraphByRMS(TGraph *grIn){
     Double_t rms=grIn->GetRMS(2);
     Double_t *xVals = grIn->GetX();
     Double_t *yVals = grIn->GetY();
@@ -25,11 +12,12 @@ TGraph* RayTraceCorrelator::getNormalisedGraphByRMS(TGraph *grIn){
     for(int i=0;i<numPoints;i++) {
         newY[i]=(yVals[i])/rms;
     }
-    TGraph *grOut = new TGraph(numPoints,xVals,newY);
+    std::unique_ptr<TGraph> grOut{new TGraph(numPoints,xVals,newY)};
     delete [] newY;
     return grOut;    
 }
 
+// FIXME: Eventually re-write with unique pointers
 double* RayTraceCorrelator::getCorrelation_NoNorm(int length, double * oldY1, double * oldY2) {
 
     FFTWComplex * theFFT1 = FFTtools::doFFT(length, oldY1);
@@ -56,6 +44,7 @@ double* RayTraceCorrelator::getCorrelation_NoNorm(int length, double * oldY1, do
     return theOutput;
 }
 
+// FIXME: Eventually re-write with unique pointers
 TGraph* RayTraceCorrelator::getCorrelationGraph_WFweight(TGraph * gr1, TGraph * gr2) {
     //Now we'll extend this up to a power of 2
     int length = gr1 -> GetN();
@@ -192,102 +181,103 @@ TGraph* RayTraceCorrelator::getCorrelationGraph_WFweight(TGraph * gr1, TGraph * 
     return grCor;
 }
 
+// FIXME: Eventually re-write with unique pointers
 TGraph *RayTraceCorrelator::getCorrelationGraph_OSUNormalization(TGraph *gr1, TGraph *gr2){
-	TGraph *corr = FFTtools::getCorrelationGraph(gr1,gr2);
-	double RMS1 = gr1->GetRMS(2);
-	double RMS2 = gr2->GetRMS(2);
+    TGraph *corr = FFTtools::getCorrelationGraph(gr1,gr2);
+    double RMS1 = gr1->GetRMS(2);
+    double RMS2 = gr2->GetRMS(2);
 
-	double t1i = gr1->GetX()[0];
-	double t1f = gr1->GetX()[gr1->GetN()-1];
-	double t2i = gr2->GetX()[0];
-	double t2f = gr2->GetX()[gr2->GetN()-1];
-	for(int corrsamp=0; corrsamp<corr->GetN(); corrsamp++){
-		double lag, corrval;
-		corr->GetPoint(corrsamp, lag, corrval);
-		double t2i_new = t2i+lag;
-		double t2f_new = t2f+lag;
-		double integral_start=-1000000;
-		double integral_stop=-500000;
-		bool do_integral;
-		if(
-			t2i_new < t1i
-			&&
-			t2f_new < t1f
-		)
-			{
-			integral_start = t1i;
-			integral_stop = t2f_new;
-			do_integral=true;
-		}
-		else if(
-			t2i_new > t1i
-			&&
-			t2f_new > t1f
-		)
-			{
-			integral_start = t2i_new;
-			integral_stop = t1f;
-			do_integral=true;
-		}
-		else if(
-			t2i_new > t1i
-			&&
-			t2f_new < t1f
-		)
-			{
-			integral_start = t2i_new;
-			integral_stop = t2f_new;
-			do_integral=true;
+    double t1i = gr1->GetX()[0];
+    double t1f = gr1->GetX()[gr1->GetN()-1];
+    double t2i = gr2->GetX()[0];
+    double t2f = gr2->GetX()[gr2->GetN()-1];
+    for(int corrsamp=0; corrsamp<corr->GetN(); corrsamp++){
+        double lag, corrval;
+        corr->GetPoint(corrsamp, lag, corrval);
+        double t2i_new = t2i+lag;
+        double t2f_new = t2f+lag;
+        double integral_start=-1000000;
+        double integral_stop=-500000;
+        bool do_integral;
+        if(
+            t2i_new < t1i
+            &&
+            t2f_new < t1f
+        )
+            {
+            integral_start = t1i;
+            integral_stop = t2f_new;
+            do_integral=true;
+        }
+        else if(
+            t2i_new > t1i
+            &&
+            t2f_new > t1f
+        )
+            {
+            integral_start = t2i_new;
+            integral_stop = t1f;
+            do_integral=true;
+        }
+        else if(
+            t2i_new > t1i
+            &&
+            t2f_new < t1f
+        )
+            {
+            integral_start = t2i_new;
+            integral_stop = t2f_new;
+            do_integral=true;
 
-		}
-		else if(
-			t2i_new < t1i
-			&&
-			t2f_new > t1f
-		){
-			integral_start = t1i;
-			integral_stop = t1f;
-			do_integral=true;
-		}
-		else if(
-			(t2i_new-t1i)<0.0001
-		){
-			integral_start = t1i;
-			integral_stop = t1f;
-		}
-		double integral_gr1=0.;
-		double integral_gr2=0.;
-		int n_overlap_1=0;
-		int n_overlap_2=0;
-		if(do_integral){
-			for(int samp1=0; samp1<gr1->GetN(); samp1++){
-				double thisX, thisY;
-				gr1->GetPoint(samp1,thisX,thisY);
-				if(thisX>integral_start && thisX<integral_stop){
-					integral_gr1+=thisY*thisY;
-					n_overlap_1++;
-				}
-			}
-			for(int samp2=0; samp2<gr2->GetN(); samp2++){
-				double thisX, thisY;
-				gr2->GetPoint(samp2, thisX, thisY);
-				thisX+=lag;
-				if(thisX>integral_start && thisX<integral_stop){
-					integral_gr2+=thisY*thisY;
-					n_overlap_2++;
-				}
-			}
-			if(integral_gr1>0. && integral_gr2>0. && n_overlap_1>1){
-				corrval*=1./(sqrt(n_overlap_1)*RMS1*RMS2);
-			}
-			else{
-				corrval=0.;
-			}
-			corr->SetPoint(corrsamp,lag,corrval);
-		}
-		else{
-			corr->SetPoint(corrsamp,lag,0.);
-		}
-	}
-	return corr;
+        }
+        else if(
+            t2i_new < t1i
+            &&
+            t2f_new > t1f
+        ){
+            integral_start = t1i;
+            integral_stop = t1f;
+            do_integral=true;
+        }
+        else if(
+            (t2i_new-t1i)<0.0001
+        ){
+            integral_start = t1i;
+            integral_stop = t1f;
+        }
+        double integral_gr1=0.;
+        double integral_gr2=0.;
+        int n_overlap_1=0;
+        int n_overlap_2=0;
+        if(do_integral){
+            for(int samp1=0; samp1<gr1->GetN(); samp1++){
+                double thisX, thisY;
+                gr1->GetPoint(samp1,thisX,thisY);
+                if(thisX>integral_start && thisX<integral_stop){
+                    integral_gr1+=thisY*thisY;
+                    n_overlap_1++;
+                }
+            }
+            for(int samp2=0; samp2<gr2->GetN(); samp2++){
+                double thisX, thisY;
+                gr2->GetPoint(samp2, thisX, thisY);
+                thisX+=lag;
+                if(thisX>integral_start && thisX<integral_stop){
+                    integral_gr2+=thisY*thisY;
+                    n_overlap_2++;
+                }
+            }
+            if(integral_gr1>0. && integral_gr2>0. && n_overlap_1>1){
+                corrval*=1./(sqrt(n_overlap_1)*RMS1*RMS2);
+            }
+            else{
+                corrval=0.;
+            }
+            corr->SetPoint(corrsamp,lag,corrval);
+        }
+        else{
+            corr->SetPoint(corrsamp,lag,0.);
+        }
+    }
+    return corr;
 }

--- a/AraCorrelator/makeRTCorrelationMaps.cxx
+++ b/AraCorrelator/makeRTCorrelationMaps.cxx
@@ -38,10 +38,10 @@ int main(int argc, char **argv)
     // setup the paths to our ray tracing tables
     double radius = 300.;
     double angular_size = 1.;
-    int iceModel = 0;
+    int iceModel = 40;
     char dirPath[500];
     char refPath[500];
-    std::string topDir = "/cvmfs/ara.opensciencegrid.org/data/raytrace_tables/";
+    std::string topDir = "/cvmfs/icecube.osgstorage.org/icecube/PUBLIC/groups/arasoft/raytrace_timing_tables/";
     sprintf(dirPath, "%s/arrivaltimes_station_%d_icemodel_%d_radius_%.2f_angle_%.2f_solution_0.root",
         topDir.c_str(), station, iceModel, radius, angular_size
     );
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
     eventTree->SetBranchAddress("event", &rawAtriEvPtr);
     Long64_t numEntries=eventTree->GetEntries();
 
-    numEntries=10;
+    numEntries=100;
     for(Long64_t event=0;event<numEntries;event++) {
         eventTree->GetEntry(event);
 
@@ -104,23 +104,23 @@ int main(int argc, char **argv)
             interpolatedWaveforms[i] = grInt;
             delete gr;
         }
-        std::vector<TGraph*> corrFunctions = theCorrelator->GetCorrFunctions(pairs, interpolatedWaveforms); // apply Hilbert envelope is default
+        auto corrFunctions = theCorrelator->GetCorrFunctions(pairs, interpolatedWaveforms); // apply Hilbert envelope is default
 
         // get the map
-        TH2D *dirMap = theCorrelator->GetInterferometricMap(pairs, corrFunctions, 0); // direct solution
+        auto dirMap = theCorrelator->GetInterferometricMap(pairs, corrFunctions, 0); // direct solution
 
         // draw and save the map
         gStyle->SetOptStat(0);
         TCanvas *c = new TCanvas("", "", 2200, 850);
         c->Divide(2,1);
             c->cd(1);
-            dirMap->Draw("colz"); // standard colz projection
-            dirMap->GetXaxis()->SetTitle("Phi [deg]");
-            dirMap->GetYaxis()->SetTitle("Theta [deg]");
-            dirMap->GetZaxis()->SetTitle("Summed Correlation");
-            dirMap->SetTitle("Standard colz Projection");
+            dirMap.Draw("colz"); // standard colz projection
+            dirMap.GetXaxis()->SetTitle("Phi [deg]");
+            dirMap.GetYaxis()->SetTitle("Theta [deg]");
+            dirMap.GetZaxis()->SetTitle("Summed Correlation");
+            dirMap.SetTitle("Standard colz Projection");
             gPad->SetRightMargin(0.15);
-        TH2D *dirMap_copy = (TH2D*) dirMap->Clone();
+        auto dirMap_copy = (TH2D*) dirMap.Clone();
             c->cd(2);
             dirMap_copy->Draw("z aitoff"); // aitoff projection
             dirMap_copy->GetXaxis()->SetTitle("Phi [deg]");
@@ -131,14 +131,11 @@ int main(int argc, char **argv)
         sprintf(title,"maps_ev%d.png", event);
         c->SaveAs(title);
         delete c;
+        delete dirMap_copy;
 
         // cleanup
-        delete dirMap;
         for(int i=0; i<16; i++){
             delete interpolatedWaveforms[i];
-        }
-        for(int i=0; i<corrFunctions.size(); i++){
-            delete corrFunctions[i];
         }
         delete realAtriEvPtr;
 


### PR DESCRIPTION
Major update to the RayTraceCorrelator.
Namely, I have rewritten the getCorrFunctions method to use unique pointers for internal management, and to return a vector of TGraphs, instead of TGraph*. So std::vector<TGraph> instead of std::vector<TGraph*>.

I also modified the GetInterferometricMap routine to take as an input the vector<TGraph>, and it now returns a TH2D, not TH2D*. This is done to make these objects much more memory safe, especially when called from pyroot.