### PR TITLE
Speed up the ray trace correlator

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -478,6 +478,8 @@ TH2D RayTraceCorrelator::GetInterferometricMap(
 
     TH2D histMap("", "", this->numPhiBins_, -180, 180, this->numThetaBins_, -90, 90);
 
+    int numGlobalBins = arrivalDelays.first[solNum][0].size();
+
     // now, make the map
     for(auto iter = pairs.begin(); iter != pairs.end(); ++iter){
         int pairNum = iter->first;
@@ -491,14 +493,14 @@ TH2D RayTraceCorrelator::GetInterferometricMap(
         double scale = weight_iter->second;
 
         // get the global bins and delays for this solution
-        auto& it_bins = arrivalDelays.first;
-        auto& it_delays = arrivalDelays.second;
+        auto& it_bins = arrivalDelays.first[solNum][pairNum];
+        auto& it_delays = arrivalDelays.second[solNum][pairNum];
         auto the_corr = corrFunctions[pairNum].get();
 
-        for(int iterBin = 0; iterBin < it_bins[solNum][pairNum].size(); iterBin++){
+        for(int iterBin = 0; iterBin < numGlobalBins; iterBin++){
             
-            int& globalBin = it_bins[solNum][pairNum][iterBin];
-            double& dt = it_delays[solNum][pairNum][iterBin];
+            int& globalBin = it_bins[iterBin];
+            double& dt = it_delays[iterBin];
             histMap.SetBinContent(globalBin, histMap.GetBinContent(globalBin)+(the_corr->Eval(dt)*scale));
         
         }

--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -1,5 +1,6 @@
 //C/C++ includes
 #include <iostream>
+#include <numeric>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <stdexcept>

--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -275,7 +275,6 @@ std::vector<TGraph> RayTraceCorrelator::GetCorrFunctions(
     // first, calculate all of the correlation functions
     // for performance reasons, it's actually better to store
     // the correlation functions as a vector
-    // std::vector<std::unique_ptr<ROOT::Math::Interpolator>> corrFunctions;
     std::vector<TGraph> corrFunctions;
     for(auto iter = pairs.begin(); iter != pairs.end(); ++iter){
         int pairNum = iter->first;
@@ -368,10 +367,6 @@ std::pair<
                 for(int thetaBin=0; thetaBin < this->numThetaBins_; thetaBin++){
                     
                     int globalBin = (phiBin + 1) + (thetaBin + 1) * (this->numPhiBins_ + 2);
-
-                    if ((globalBin<0) or (globalBin > 65522)){
-                        std::cout<<"Naughty constructor bin " <<globalBin<<std::endl;
-                    }
 
                     double arrival_time1 = LookupArrivalTimes(ant1, solNum, thetaBin, phiBin);
                     double arrival_time2 = LookupArrivalTimes(ant2, solNum, thetaBin, phiBin);
@@ -491,7 +486,7 @@ TH2D RayTraceCorrelator::GetInterferometricMap(
     // and a variable to control the loop over bins we actually populated
     // this is NOT the same thing as the number of bins in the TH2D
     // since the number of bins in the 2D hist is different than the number of bins we have cached
-    // because of overflow bins
+    // because of overflow and underflow bins
     const int nGlobalBinsToIter = arrivalDelays.first[0][0].size();
 
     // now, make the map

--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -476,9 +476,8 @@ TH2D RayTraceCorrelator::GetInterferometricMap(
         throw std::invalid_argument(errorMessage);
     }
 
-    TH2D histMap("", "", this->numPhiBins_, -180, 180, this->numThetaBins_, -90, 90);
-
     int numGlobalBins = arrivalDelays.first[solNum][0].size();
+    std::vector<double> summedCorr(numGlobalBins);
 
     // now, make the map
     for(auto iter = pairs.begin(); iter != pairs.end(); ++iter){
@@ -498,12 +497,15 @@ TH2D RayTraceCorrelator::GetInterferometricMap(
         auto the_corr = corrFunctions[pairNum].get();
 
         for(int iterBin = 0; iterBin < numGlobalBins; iterBin++){
-            
             int& globalBin = it_bins[iterBin];
             double& dt = it_delays[iterBin];
-            histMap.SetBinContent(globalBin, histMap.GetBinContent(globalBin)+(the_corr->Eval(dt)*scale));
-        
+            summedCorr[globalBin]+=the_corr->Eval(dt)*scale;
         }
+    }
+
+    TH2D histMap("", "", this->numPhiBins_, -180, 180, this->numThetaBins_, -90, 90);
+    for(int iterBin=0; iterBin < numGlobalBins; iterBin++){
+        histMap.SetBinContent(iterBin+1, summedCorr[iterBin]);
     }
 
     return histMap;

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -6,6 +6,9 @@
 class TGraph;
 class TH2D;
 class AraGeomTool;
+#include "Math/Interpolator.h"
+#include "Math/InterpolationTypes.h"
+
 
 class RayTraceCorrelator : public TObject
 {
@@ -42,8 +45,7 @@ class RayTraceCorrelator : public TObject
         std::vector < std::vector < std::vector < std::vector < double > > > > arrivalThetas_;
         std::vector < std::vector < std::vector < std::vector < double > > > > arrivalPhis_;
         std::vector < std::vector < std::vector < std::vector < double > > > > launchThetas_;
-        std::vector < std::vector < std::vector < std::vector < double > > > > launchPhis_;        
-
+        std::vector < std::vector < std::vector < std::vector < double > > > > launchPhis_;
         
         void ConfigureArrivalVectors(); ///< Function to set the dimensions of arrivalTimes_, arrivalThetas_, etc. correctly
 
@@ -59,6 +61,10 @@ class RayTraceCorrelator : public TObject
         std::vector<double> GetPhiAngles(){ return phiAngles_; }
         std::vector<double> GetThetaAngles(){ return thetaAngles_; }
 
+
+        std::pair< 
+    std::vector< std::vector< std::vector< int > > >,
+    std::vector< std::vector< std::vector< double > > > > GetArrivalDelays(std::map<int, std::vector<int > > pairs);
 
         //! function to load the arrival time tables
         void LoadArrivalTimeTables(const std::string &filename, int solNum);
@@ -97,7 +103,7 @@ class RayTraceCorrelator : public TObject
             \param applyHilbertEnvelope whether or not to apply hilbert enveloping to the correlation functions
             \return a std::vector of the correlation functions (one for each pair)
         */
-        std::vector<TGraph> GetCorrFunctions(
+        std::vector<std::unique_ptr<ROOT::Math::Interpolator>> GetCorrFunctions(
             std::map<int, std::vector<int> > pairs,
             std::map<int, TGraph*> interpolatedWaveforms,
             bool applyHilbertEnvelope = true
@@ -174,7 +180,8 @@ class RayTraceCorrelator : public TObject
         */
         TH2D GetInterferometricMap(
             std::map<int, std::vector<int> > pairs,
-            std::vector<TGraph> corrFunctions,
+            std::vector<std::unique_ptr<ROOT::Math::Interpolator>> &corrFunctions,
+            std::pair< std::vector< std::vector< std::vector< int > > >, std::vector< std::vector< std::vector< double > > > > &arrivalDelays,
             int solNum,
             std::map<int, double> weights = {}
         );

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -62,9 +62,24 @@ class RayTraceCorrelator : public TObject
         std::vector<double> GetThetaAngles(){ return thetaAngles_; }
 
 
+        //! Get the arrival delays
+        /*!
+            \param pairs the pairs of antennas for which you want us to compute delays
+            \return a complicated data structure; see more information below
+
+            In this refactorization of the RTC, we want to cache the arrival *delays* for a give pair.
+            And we want to store them time ordered, for potential future performance reasons (e.g. wanting to use a GSL interpolatino accelerator).
+            For this reason, for a given solution/pair we need to keep track of *both* the TH2D bin it belongs to, and, the actual time delay.
+            So this function returns a std::pair.
+            pair->first is the bins, pair->second are the delays
+            So pair->first[solNum][pair][iterator] gives you the TH2D bin number for a given solution and pair and global "iterator" variable.
+            while pair->second[solNum][pair] gives you the delay in ns for a given solution, pair, and global "iterator" variable.
+            The TH2D bin it belongs to is in pair->first.
+        */
+
         std::pair< 
-    std::vector< std::vector< std::vector< int > > >,
-    std::vector< std::vector< std::vector< double > > > > GetArrivalDelays(std::map<int, std::vector<int > > pairs);
+            std::vector< std::vector< std::vector< int > > >,
+            std::vector< std::vector< std::vector< double > > > > GetArrivalDelays(std::map<int, std::vector<int > > pairs);
 
         //! function to load the arrival time tables
         void LoadArrivalTimeTables(const std::string &filename, int solNum);
@@ -103,7 +118,7 @@ class RayTraceCorrelator : public TObject
             \param applyHilbertEnvelope whether or not to apply hilbert enveloping to the correlation functions
             \return a std::vector of the correlation functions (one for each pair)
         */
-        std::vector<std::unique_ptr<ROOT::Math::Interpolator>> GetCorrFunctions(
+        std::vector<TGraph>GetCorrFunctions(
             std::map<int, std::vector<int> > pairs,
             std::map<int, TGraph*> interpolatedWaveforms,
             bool applyHilbertEnvelope = true
@@ -174,15 +189,16 @@ class RayTraceCorrelator : public TObject
         /*!
             \param pairs a std::map of antenna pairs
             \param corrFunctions a std::vector of correlation functions, one for each pair in pairs (in that order!)
+            \param arrivalDelays a std::pair; the arrival delays; this is the output of GetArrivalDelays
             \param solNum whether to have the first or second (0 or 1) solution hypothesis
             \param weights weights to apply to each map; default = equal weights, or 1/pairs.size()
             \return a 2D histogram with the values filled with the interferometric sums
         */
         TH2D GetInterferometricMap(
-            std::map<int, std::vector<int> > pairs,
-            std::vector<std::unique_ptr<ROOT::Math::Interpolator>> &corrFunctions,
-            std::pair< std::vector< std::vector< std::vector< int > > >, std::vector< std::vector< std::vector< double > > > > &arrivalDelays,
-            int solNum,
+            const std::map<int, std::vector<int> > pairs,
+            const std::vector<TGraph> &corrFunctions,
+            const std::pair< std::vector< std::vector< std::vector< int > > >, std::vector< std::vector< std::vector< double > > > > &arrivalDelays,
+            const int solNum,
             std::map<int, double> weights = {}
         );
 

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -6,9 +6,6 @@
 class TGraph;
 class TH2D;
 class AraGeomTool;
-#include "Math/Interpolator.h"
-#include "Math/InterpolationTypes.h"
-
 
 class RayTraceCorrelator : public TObject
 {

--- a/AraCorrelator/makeRTCorrelationMaps.cxx
+++ b/AraCorrelator/makeRTCorrelationMaps.cxx
@@ -16,6 +16,12 @@
 #include "FFTtools.h"
 RawAtriStationEvent *rawAtriEvPtr;
 
+double getUnixTime(void){
+    struct timespec tv;
+    if(clock_gettime(CLOCK_REALTIME, &tv) != 0) return 0;
+    return (tv.tv_sec + (tv.tv_nsec/1000000000.0));
+}
+
 int main(int argc, char **argv)
 {
     double interpV = 0.4;
@@ -87,7 +93,7 @@ int main(int argc, char **argv)
     eventTree->SetBranchAddress("event", &rawAtriEvPtr);
     Long64_t numEntries=eventTree->GetEntries();
 
-    numEntries=100;
+    numEntries=500;
     for(Long64_t event=0;event<numEntries;event++) {
         eventTree->GetEntry(event);
 
@@ -109,8 +115,13 @@ int main(int argc, char **argv)
         auto corrFunctions = theCorrelator->GetCorrFunctions(pairs, interpolatedWaveforms); // apply Hilbert envelope is default
 
         // get the map
+        double start_time = getUnixTime();
         auto dirMap = theCorrelator->GetInterferometricMap(pairs, corrFunctions, arrivalDelays, 0); // direct solution
-
+        double stop_time = getUnixTime();
+        double difference = stop_time - start_time;
+        std::cout<<"Time to make single map is "<<difference<<std::endl;  
+    
+        
         // draw and save the map
         gStyle->SetOptStat(0);
         TCanvas *c = new TCanvas("", "", 2200, 850);

--- a/AraCorrelator/makeRTCorrelationMaps.cxx
+++ b/AraCorrelator/makeRTCorrelationMaps.cxx
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
 
     printf("------------------\n");
 
+    auto arrivalDelays = theCorrelator->GetArrivalDelays(pairs);
 
     /////////////////////////////////////////////////
     /////////////////////////////////////////////////
@@ -104,10 +105,17 @@ int main(int argc, char **argv)
             interpolatedWaveforms[i] = grInt;
             delete gr;
         }
+
+        // std::vector<ROOT::Math::Interpolator> vecy;
+        // std::vector<double> stuff_t; stuff_t.push_back(0); stuff_t.push_back(1);
+        // std::vector<double> stuff_v; stuff_v.push_back(0); stuff_v.push_back(1);
+        // ROOT::Math::Interpolator me(stuff_t, stuff_v, ROOT::Math::Interpolation::kLINEAR);
+        // vecy.push_back(me);
+
         auto corrFunctions = theCorrelator->GetCorrFunctions(pairs, interpolatedWaveforms); // apply Hilbert envelope is default
 
         // get the map
-        auto dirMap = theCorrelator->GetInterferometricMap(pairs, corrFunctions, 0); // direct solution
+        auto dirMap = theCorrelator->GetInterferometricMap(pairs, corrFunctions, arrivalDelays, 0); // direct solution
 
         // draw and save the map
         gStyle->SetOptStat(0);

--- a/AraCorrelator/makeRTCorrelationMaps.cxx
+++ b/AraCorrelator/makeRTCorrelationMaps.cxx
@@ -106,12 +106,6 @@ int main(int argc, char **argv)
             delete gr;
         }
 
-        // std::vector<ROOT::Math::Interpolator> vecy;
-        // std::vector<double> stuff_t; stuff_t.push_back(0); stuff_t.push_back(1);
-        // std::vector<double> stuff_v; stuff_v.push_back(0); stuff_v.push_back(1);
-        // ROOT::Math::Interpolator me(stuff_t, stuff_v, ROOT::Math::Interpolation::kLINEAR);
-        // vecy.push_back(me);
-
         auto corrFunctions = theCorrelator->GetCorrFunctions(pairs, interpolatedWaveforms); // apply Hilbert envelope is default
 
         // get the map


### PR DESCRIPTION
This is a pretty substantial optimization effort undertake with @marcomuzio.

We added caching of the arrival delays for pairs, since this is stable across events.

We also worked pretty hard to make the map  making routine leaner and meaner.
This involves make it slightly less readable, and in some ways, less safe.
E.g. we pulled out some sanity checks (if statements) to make things faster.
So be careful!

Overall we found about a factor of 5-6 speed improvement in the time needed to call the map routine. So we think that's worth it.