### PR TITLE
Fixed segfault on RTC destructor call

### DIFF
--- a/AraCorrelator/RayTraceCorrelator.cxx
+++ b/AraCorrelator/RayTraceCorrelator.cxx
@@ -66,7 +66,7 @@ void RayTraceCorrelator::SetAngularConfig(double angularSize){
     angularSize_ = angularSize;
     numPhiBins_ = int(360. / angularSize);
     numThetaBins_ = int(180. / angularSize);
-    dummyMap = std::shared_ptr<TH2D>(new TH2D("","",numPhiBins_, -180, 180, numThetaBins_, -90, 90));
+    dummyMap = std::make_shared<TH2D>(TH2D("","",numPhiBins_, -180, 180, numThetaBins_, -90, 90));
 }
 
 int RayTraceCorrelator::ConvertAnglesToTH2DGlobalBin(double theta, double phi){
@@ -518,3 +518,5 @@ void RayTraceCorrelator::LookupLaunchAngles(
     launchTheta = launchThetas_.at(solNum).at(ant).GetBinContent(globalBin);
     launchPhi = launchPhis_.at(solNum).at(ant).GetBinContent(globalBin);
 }
+
+

--- a/AraCorrelator/RayTraceCorrelator.h
+++ b/AraCorrelator/RayTraceCorrelator.h
@@ -50,7 +50,7 @@ class RayTraceCorrelator : public TObject
         double GetAngularSize(){ return angularSize_; }
         double GetRadius(){ return radius_; }
         double GetNumAntennas(){ return numAntennas_; }
-        std::shared_ptr<TH2D> GetTemplateMap(){return dummyMap;}
+        std::weak_ptr<TH2D> GetTemplateMap(){return dummyMap;}
 
 
         //! constructor for the RayTraceCorrelator
@@ -249,3 +249,6 @@ class RayTraceCorrelator : public TObject
 
 };
 #endif //RAYTRACECORRELATOR_H
+
+
+


### PR DESCRIPTION
A segfault was being thrown when programs using the RTC were ended. This seems to have been due to ROOT owning the `TH2D` created via `new`, causing the same object to be destructed twice: once by ROOT and once by the `std::shared_ptr`. Using `std::make_shared` seems to avoid this by ensuring only the `std::shared_ptr` owns the object. (I also updated the get function for the template map to use a `std::weak_ptr` to avoid any chance of circular references.)

This was a little subtle to understand, so admittedly I appealed to chatgpt. Here's its explanation which may be more clear:

### Prompt:

You are a c++ expert, in particular with the ROOT library. Why does this code cause a segfault on destruction:

int numPhiBins_ = 360;
int numThetaBins_ = 180;
std::shared_ptr<TH2D> dummyMap;
dummyMap = std::shared_ptr<TH2D>(new TH2D("","",numPhiBins_, -180, 180, numThetaBins_, -90, 90));

But this code does not:

int numPhiBins_ = 360;
int numThetaBins_ = 180;
std::shared_ptr<TH2D> dummyMap;
dummyMap = std::make_shared<TH2D>(TH2D("","",numPhiBins_, -180, 180, numThetaBins_, -90, 90));

### Response:


The reason the first code causes a segmentation fault while the second does not is related to how `std::shared_ptr` manages ownership and destruction of the object.

#### First Case:

```cpp
dummyMap = std::shared_ptr<TH2D>(new TH2D("", "", numPhiBins_, -180, 180, numThetaBins_, -90, 90));
```

Here, you are manually allocating the `TH2D` object on the heap using `new`. This raw pointer is then wrapped in a `std::shared_ptr`, which means `std::shared_ptr` is responsible for managing the lifetime of this object, including its destruction.

However, ROOT histograms (like `TH2D`) are usually automatically registered with ROOT's global object management system when created. ROOT keeps track of these histograms to perform things like drawing, saving, and managing memory. When ROOT destroys the histogram (e.g., when a ROOT session ends or the object is no longer referenced), it might delete the object itself, leading to a double deletion: one by the `std::shared_ptr` and another by ROOT's memory management. This can lead to a segmentation fault when the object is destroyed twice.

#### Second Case:

```cpp
dummyMap = std::make_shared<TH2D>(TH2D("", "", numPhiBins_, -180, 180, numThetaBins_, -90, 90));
```

In this case, `std::make_shared` is used, which constructs the object directly inside the memory managed by the `std::shared_ptr`. This avoids the use of `new` and ensures that the object is only managed by `std::shared_ptr`. However, there is an important distinction: in this case, the `TH2D` is constructed as a temporary object on the stack, and then a copy of that object is made inside the `std::shared_ptr`-managed memory. ROOT's global object manager does not track this particular object because it never registers temporary stack-based objects in the same way as heap-allocated objects.

#### Root Cause:

- **First case:** The `TH2D` is heap-allocated using `new`, and ROOT likely takes ownership and tracks the histogram. The `std::shared_ptr` is also trying to manage the same object, leading to potential double deletion.
- **Second case:** The `TH2D` is created as a stack object, and then a copy of it is managed by `std::shared_ptr`. ROOT does not track the original temporary object, avoiding conflicts.

#### Solution:

To avoid this issue in the first case, you can prevent ROOT from managing the histogram by turning off automatic registration in ROOT's global directory:

```cpp
TH2D* hist = new TH2D("", "", numPhiBins_, -180, 180, numThetaBins_, -90, 90);
hist->SetDirectory(0);  // Prevent ROOT from managing this histogram
dummyMap = std::shared_ptr<TH2D>(hist);
```

This will prevent ROOT from taking ownership of the object, allowing `std::shared_ptr` to manage it safely.