### PR TITLE
Final block offset correction updates

### DIFF
--- a/AraEvent/AraEventCalibrator.h
+++ b/AraEvent/AraEventCalibrator.h
@@ -43,6 +43,7 @@ namespace AraCalType {
         kLatestCalib                    = 0x09, ///< Currenly this is kSecondCalibPlusCables
         kLatestCalib14to20_Bug          = 0x0A, ///<new calibration type: everything except voltage calibration. Will reproduce "kLatestCalib" bug present from between ~2014 to September 2020. Use with caution!
         kLatestCalibWithOutZeroMean     = 0x0B, ///< Performs kLatestCalib except the ADC and Voltage zero meaning, 19-12-2021 -MK-
+        kLatestCalib_NoBlockCorrection  = 0x0C, ///< Performs kLatestCalib except the block offset correction
         
         /*!
             Useful CalType for raw data debugging, 19-12-2021 -MK- 
@@ -54,14 +55,14 @@ namespace AraCalType {
             ~WithOut1stBlockAndBadSamples:  Remove 1st block and bad samples by applying TrimFirstBlock(), TimingCalibrationAndBadSampleReomval(), and ApplyCableDelay() 
                                             The number of samples and time width betweens samples will be the same as fully calibrated WF (kLatestCalib). So, users can easy to compare with it.  
         */ 
-        kOnlyPed                             = 0X0C, 
-        kOnlyPedWithOut1stBlock              = 0x0D, ///< It is useful when user makes pedestal by their own custom repeder scripts
-        kOnlyPedWithOut1stBlockAndBadSamples = 0x0E,
-        kOnlyADC                             = 0x0F, ///< Same as kNoCalib
-        kOnlyADCWithOut1stBlock              = 0x10,
-        kOnlyADCWithOut1stBlockAndBadSamples = 0x11,
-        kJustPedWithOut1stBlock              = 0x12, ///< subtract peds and remove first block , 05-03-2022 -MK-
-        kJustPedWithOut1stBlockAndBadSamples = 0x13, ///< subtract peds and remove first block and bad sampeles. useful for checking the wf that has large offet from ped
+        kOnlyPed                             = 0X0D, 
+        kOnlyPedWithOut1stBlock              = 0x0E, ///< It is useful when user makes pedestal by their own custom repeder scripts
+        kOnlyPedWithOut1stBlockAndBadSamples = 0x0F,
+        kOnlyADC                             = 0x10, ///< Same as kNoCalib
+        kOnlyADCWithOut1stBlock              = 0x11,
+        kOnlyADCWithOut1stBlockAndBadSamples = 0x12,
+        kJustPedWithOut1stBlock              = 0x13, ///< subtract peds and remove first block , 05-03-2022 -MK-
+        kJustPedWithOut1stBlockAndBadSamples = 0x14, ///< subtract peds and remove first block and bad sampeles. useful for checking the wf that has large offet from ped
 
         /*! 
             Get sample index. 
@@ -70,12 +71,12 @@ namespace AraCalType {
             and debug which elements of timing / voltage calibration were used to calibrate the event
             26-11-2022 -MK-
         */
-        kOnlySamp                             = 0x14,
-        kOnlySampWithOut1stBlock              = 0x15,
-        kOnlySampWithOut1stBlockAndBadSamples = 0x16,
+        kOnlySamp                             = 0x15,
+        kOnlySampWithOut1stBlock              = 0x16,
+        kOnlySampWithOut1stBlockAndBadSamples = 0x17,
 
         //! full calibration without 1st block triming, 06-02-2023 -MK-
-        kLatestCalibWithOutTrimFirstBlock     = 0x17   
+        kLatestCalibWithOutTrimFirstBlock     = 0x18,   
 
 
     } AraCalType_t;


### PR DESCRIPTION
Implemented changes based on feedback from [PR#85](https://github.com/ara-software/AraRoot/pull/85). I added a calibration option to implement `kLatestCalib` but without the block offset correction, `kLatestCalib_NoBlockCorrection`.

In particular, I investigated using Eigen3 to solve the linear system of equations but found that it was slower than the ROOT implementation. In any case, this part of the function is not a bottleneck and either implementation does not significantly change the function's run time. The main bottlenecks in the function are the first FFT (for the first event calibrated) and then filling the matrix of constants (for events after the first calibration). 

Here is an updated benchmarking of the correction compared to the time for the full calibration. Note that due to caching of some variables, this time is significantly faster after the first event is calibrated ("first iteration"). Events calibrated after the first calibration are referred to as a "bulk iteration" below. To examples are given: a calibration for A3 (which discards some samples) and for A4 (which keeps all samples). Benchmark times were found running on `cobalt-14`.

**Benchmarks**

- Station 3 
  - No correction:
    - First iteration: 1644 ms (total)
    - Bulk iteration: 11 ms (total)
  - With correction: 
    - First iteration: 223 ms (correction), 1836 ms (total)
    - Bulk iteration: 10 ms (correction), 20 ms (total)
- Station 4 
  - No correction: 
    - First iteration: 771 ms (total)
    - Bulk iteration: 14 ms (total)
  - With correction: 
    - First iteration: 116 ms (correction), 907 ms (total)
    - Bulk iteration: 16 ms (correction), 29 ms (total)