### PR TITLE
Update livetime config log read in

### DIFF
--- a/AraEvent/AraQualCuts.cxx
+++ b/AraEvent/AraQualCuts.cxx
@@ -419,6 +419,7 @@ void AraQualCuts::loadLivetimeConfiguration(int stationId)
       stationId = 1;
     
     int start, config, year;
+    int trigWin, readoutWin;
 
     configStart.clear();
     configNum.clear();
@@ -443,7 +444,7 @@ void AraQualCuts::loadLivetimeConfiguration(int stationId)
       
       while(getline(str, word, ','))
         words.push_back(word);
-      if(words.size() != 3)
+      if(words.size() != 5)
         throw std::runtime_error("Livetime config log file not formatted correctly! \
                                   \nSee AraEvent/livetimeConfigs/README.md");
       if(words[0] == "RunNo") // header, skip this line
@@ -451,16 +452,20 @@ void AraQualCuts::loadLivetimeConfiguration(int stationId)
       start = std::stoi(words[0]);  
       config = std::stoi(words[1]);
       year = std::stoi(words[2]);     
+      trigWin = std::stoi(words[3]);
+      readoutWin = std::stoi(words[4]);
  
       // check for unexpected data types
       //// check for entries like: "1.5" and "11x" that might have silently converted to int
       if(std::to_string(start) != words[0] || 
           std::to_string(config) != words[1] ||
-          std::to_string(year) != words[2]) // should be able to convert back fine if this was an integer
+          std::to_string(year) != words[2] ||
+          std::to_string(trigWin) != words[3] ||
+          std::to_string(readoutWin) != words[4]) // should be able to convert back fine if this was an integer
         throw std::runtime_error("Unexpected data type in livetime config log file! \
                                  \nSee AraEvent/livetimeConfigs/README.md");
       //// check for negative entries
-      if(start < 0 || config < 0 || year < 0)
+      if(start < 0 || config < 0 || year < 0 || trigWin < 0 || readoutWin < 0)
         throw std::runtime_error("Livetime config log file has a negative entry! \
                                  \nSee AraEvent/livetimeConfigs/README.md");
 
@@ -468,6 +473,8 @@ void AraQualCuts::loadLivetimeConfiguration(int stationId)
       configStart.push_back(start);
       configNum.push_back(config);
       repYear.push_back(year);
+      trigWindow.push_back(trigWin);
+      readoutWindow.push_back(readoutWin);
     }
     configLogFile.close();
 
@@ -538,3 +545,58 @@ int AraQualCuts::getLivetimeConfigurationYear(const int configNumber, int statio
 
     return year;
 }
+
+//! Returns the typical trigger window for a given livetime configuration and station 
+/*!
+    \param configNumber the livetime configuration number
+    \param stationId the station Id number 
+    \return trigWin the trigger window 
+*/
+int AraQualCuts::getLivetimeConfigurationTriggerWindow(const int configNumber, int stationId)
+{
+
+    if(configStart.empty() || loadedStationId != stationId)
+      loadLivetimeConfiguration(stationId);
+
+    // find the right configuration
+    int trigWin = -1;
+    for(unsigned int i = 0; i < configNum.size(); ++i) {
+      if(configNum[i] == configNumber)
+        trigWin = trigWindow[i];       
+    }
+
+    if(trigWin == -1)
+      throw std::runtime_error("Livetime configuration trigger window not found!");
+
+    return trigWin;
+
+
+}
+
+//! Returns the typical readout window for a given livetime configuration and station 
+/*!
+    \param configNumber the livetime configuration number
+    \param stationId the station Id number 
+    \return readoutWin the readout window 
+*/
+int AraQualCuts::getLivetimeConfigurationReadoutWindow(const int configNumber, int stationId)
+{
+
+    if(configStart.empty() || loadedStationId != stationId)
+      loadLivetimeConfiguration(stationId);
+
+    // find the right configuration
+    int readoutWin = -1;
+    for(unsigned int i = 0; i < configNum.size(); ++i) {
+      if(configNum[i] == configNumber)
+        readoutWin = readoutWindow[i];       
+    }
+
+    if(readoutWin == -1)
+      throw std::runtime_error("Livetime configuration readout window not found!");
+
+    return readoutWin;
+
+
+}
+

--- a/AraEvent/AraQualCuts.h
+++ b/AraEvent/AraQualCuts.h
@@ -60,6 +60,12 @@ class AraQualCuts
         int getLivetimeConfigurationYear(const int configNumber, int stationId);
         int getLivetimeConfigurationYear(const int configNumber, RawAtriStationEvent *realEvent)
           { return getLivetimeConfigurationYear(configNumber, realEvent->getStationId()); }
+        int getLivetimeConfigurationTriggerWindow(const int configNumber, int stationId);
+        int getLivetimeConfigurationTriggerWindow(const int configNumber, RawAtriStationEvent *realEvent)
+          { return getLivetimeConfigurationTriggerWindow(configNumber, realEvent->getStationId()); }
+        int getLivetimeConfigurationReadoutWindow(const int configNumber, int stationId);
+        int getLivetimeConfigurationReadoutWindow(const int configNumber, RawAtriStationEvent *realEvent)
+          { return getLivetimeConfigurationReadoutWindow(configNumber, realEvent->getStationId()); }
  
     protected:
         static AraQualCuts *fgInstance; // protect against multiple instances
@@ -69,6 +75,8 @@ class AraQualCuts
         std::vector<int> configStart;
         std::vector<int> configNum;
         std::vector<int> repYear;
+        std::vector<int> trigWindow;
+        std::vector<int> readoutWindow;
 
         void loadLivetimeConfiguration(int stationId);
 };

--- a/AraEvent/AraQualCuts.h
+++ b/AraEvent/AraQualCuts.h
@@ -55,17 +55,9 @@ class AraQualCuts
         TGraph* getRollingMean(TGraph *grInt, int samplePerBlock); ///< gets the rolling average of a waveform
 
         int getLivetimeConfiguration(const int runNumber, int stationId);
-        int getLivetimeConfiguration(const int runNumber, RawAtriStationEvent *realEvent)
-          { return getLivetimeConfiguration(runNumber, realEvent->getStationId()); }
         int getLivetimeConfigurationYear(const int configNumber, int stationId);
-        int getLivetimeConfigurationYear(const int configNumber, RawAtriStationEvent *realEvent)
-          { return getLivetimeConfigurationYear(configNumber, realEvent->getStationId()); }
         int getLivetimeConfigurationTriggerWindow(const int configNumber, int stationId);
-        int getLivetimeConfigurationTriggerWindow(const int configNumber, RawAtriStationEvent *realEvent)
-          { return getLivetimeConfigurationTriggerWindow(configNumber, realEvent->getStationId()); }
         int getLivetimeConfigurationReadoutWindow(const int configNumber, int stationId);
-        int getLivetimeConfigurationReadoutWindow(const int configNumber, RawAtriStationEvent *realEvent)
-          { return getLivetimeConfigurationReadoutWindow(configNumber, realEvent->getStationId()); }
  
     protected:
         static AraQualCuts *fgInstance; // protect against multiple instances


### PR DESCRIPTION
This updates the livetime configuration log read in to read in the trigger and readout window columns added in [PR#86](https://github.com/ara-software/AraRoot/pull/86). Also adds corresponding get functions. 

NOTE: This update _will_ break AraProc for stations whose logs are not yet updated.