### PR TITLE
Fixed bug in block offset correction

### DIFF
--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1537,6 +1537,10 @@ void AraEventCalibrator::CorrectBlockOffset(UsefulAtriStationEvent *theEvent, st
                 std::vector<double> tmpT(timeMapIt->second.begin(), timeMapIt->second.end());
                 std::vector<double> tmpV(voltMapIt->second.begin(), voltMapIt->second.end());
 
+                // check that we have some data points to work with
+                if(tmpT.size() == 0)
+                  continue;
+
                 // find block edges
                 std::vector<double> blockStarts; // times of the block starts
                 std::vector<double> blockEnds; // times of the block ends

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -15,6 +15,7 @@ END="\033[0m"
 #This is where we handle arguments passed to the script
 #0  Re-build programs and libraries that have been modified since last build
 #1  Complete re-build -- remove everything from the build directory and start over
+#2  Complete re-build, but with a debug build
 #99 De-bugging - build verbosely
 
 MODE=$1
@@ -75,13 +76,17 @@ mkdir -p $ARA_ROOT_DIR/build #make this directory if it doesn't exist already (i
 cd $ARA_ROOT_DIR/build
 
 #This forces a complete re-build
-if [ $MODE == 1 ] || [ $MODE == 99 ] ; then
-#    echo "Passed the test Mode == 1 or 99"
+if [ $MODE == 1 ] || [ $MODE == 2] || [ $MODE == 99 ] ; then
+#    echo "Passed the test Mode == 1, 2, or 99"
     rm -r $ARA_ROOT_DIR/build/*
 fi
 
 #Now we run cmake to produce the makefiles. The install prefix is where things will be installed to.
-cmake ../ -DCMAKE_INSTALL_PREFIX=${ARA_UTIL_INSTALL_DIR}
+if [ $MODE == 2 ] ; then
+    cmake ../ -DCMAKE_INSTALL_PREFIX=${ARA_UTIL_INSTALL_DIR} -DCMAKE_BUILD_TYPE=DEBUG
+else
+    cmake ../ -DCMAKE_INSTALL_PREFIX=${ARA_UTIL_INSTALL_DIR}
+fi
 
 if [ $MODE == 99 ] ; then
     make VERBOSE=1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ ARA ROOT based software, AraRoot, comprises several libraries and executables.
 4. Do `bash INSTALL.sh <MODE>` in the directory of the source code (i.e. in `ARA_ROOT_DIR`) - cmake will take care of the rest. <MODE> should be one of the following:
   - 0 - re-build bins / libs that have been modified
   - 1 - re-build all
+  - 2 - re-build all, but with a debug build
   - 99 - re-build debugging mode - this will produce more verbose output from the build process
 
 ## Adding Your Own Analysis Code to the CMake build structure


### PR DESCRIPTION
This fixes a segfault that occurs when trying to access elements of a time and voltage vector with no points. An if statement was added to ensure there is data to be corrected before attempting and if there isn't the function moves to the next channel.

Also added an option in `INSTALL.sh` to make a debug build to aid in debugging.