### PR TITLE
Fixed memory leak introduced in block offset correction

### DIFF
--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -973,9 +973,9 @@ void AraEventCalibrator::calibrateEvent(UsefulAtriStationEvent *theEvent, AraCal
     Double_t unixtime = theEvent->unixTime; ///< The unixtime line was added by UAL 01/26/2019.
     std::map< Int_t, std::vector <Double_t> >::iterator timeMapIt;
     std::map< Int_t, std::vector <Double_t> >::iterator voltMapIt;
-    std::vector<std::vector<int> > sampleList(CHANNELS_PER_ATRI, std::vector<int>(0)); ///< pointer for WF sample numbers
-    std::vector<std::vector<int> > blockList(CHANNELS_PER_ATRI, std::vector<int>(0)); ///< pointer for WF sample block numbers
-    std::vector<std::vector<int> > capArrayList(DDA_PER_ATRI, std::vector<int>(0)); ///< pointer for 'block number' modulo 2
+    std::vector<std::vector<int> > sampleList(CHANNELS_PER_ATRI, std::vector<int>(0)); ///< for WF sample numbers
+    std::vector<std::vector<int> > blockList(CHANNELS_PER_ATRI, std::vector<int>(0)); ///< for WF sample block numbers
+    std::vector<std::vector<int> > capArrayList(DDA_PER_ATRI, std::vector<int>(0)); ///< for 'block number' modulo 2
     Bool_t hasTrimFirstBlk = false;
     Bool_t hasTimingCalib = false; 
 


### PR DESCRIPTION
This PR fixes a memory leak that was introduced with the block offset correction part of calibration. I don't completely understand it, but it originated from the `blockList` vector being defined using `new` and then filled with `push_back` (despite a call to `delete` to clean up this vector). Changing the initialization to _not_ use `new` and passing the vector by reference fixes the leak.

Two other vectors are also defined in this way, `sampleList` and `capArrayList` (which I patterned `blockList` on). These follow a very similar set of operations in the calibration, so it's a bit of a mystery to me why they do not seem to cause a leak. However, to be safe I've converted these to also use standard `vector` initialization and to be passed by reference to functions.