### PR TITLE
Removed fallback to default pedestals.

### DIFF
--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1812,6 +1812,7 @@ void AraEventCalibrator::loadAtriPedestals(AraStationId_t stationId)
         char errMsg[500];
         sprintf(errMsg, "%s -- no pedFile passed! A pedestal file must be passed.", __FUNCTION__);
         sprintf(errMsg, "%s\n\tIt is best-practice to use a run-specific pedestal file, but ''default'' pedestals are available (use with caution): %s", errMsg, fAtriPedFile[calibIndex]);
+        sprintf(errMsg, "%s\n\tPedestal files can be set using AraEventCalibrator::setAtriPedFile(pedFile, stationId) in an AraEventCalibrator instance.", errMsg);
         throw std::runtime_error(errMsg);
     }
     

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1779,43 +1779,40 @@ void AraEventCalibrator::loadAtriPedestals(AraStationId_t stationId)
       }
     }
 
+    // if there's a ped file set, make sure it seems okay to use
     if(fGotAtriPedFile[calibIndex]==1){
         if(!fileExists(fAtriPedFile[calibIndex])){
-            fGotAtriPedFile[calibIndex]=0;
-            fprintf(stderr, "%s -- pedFile does not exist!\n", __FUNCTION__);
+            char errMsg[500];
+            sprintf(errMsg, "%s -- pedFile does not exist!\n", __FUNCTION__);
+            throw std::runtime_error(errMsg);
         }
         else if(numberOfPedestalValsInFile(fAtriPedFile[calibIndex]) != RFCHAN_PER_DDA*DDA_PER_ATRI*BLOCKS_PER_DDA*SAMPLES_PER_BLOCK){
-            fGotAtriPedFile[calibIndex]=0;
-            fprintf(stderr, "%s -- pedFile has too few values!\n", __FUNCTION__);
+            char errMsg[500];
+            sprintf(errMsg, "%s -- pedFile has too few values!\n", __FUNCTION__);
+            throw std::runtime_error(errMsg);
         }
     }
 
+    // if there's no ped file set, point user to likely place to find default pedestals
     if(fGotAtriPedFile[calibIndex]==0){
-        char *pedFileEnv = getenv( "ARA_ATRI_PEDESTAL_FILE" );
-        if ( pedFileEnv == NULL ) {
-            char calibDir[FILENAME_MAX];
-            char *calibEnv=getenv("ARA_CALIB_DIR");
-            if(!calibEnv) {
-                char *utilEnv=getenv("ARA_UTIL_INSTALL_DIR");
-                if(!utilEnv) {
-                    sprintf(calibDir,"calib");
-                    // fprintf(stdout,"AraEventCalibrator::loadAtriPedestals(): INFO - Pedestal file [from ./calib]");
-                } else {
-                    sprintf(calibDir,"%s/share/araCalib",utilEnv);
-                    // fprintf(stdout,"AraEventCalibrator::loadAtriPedestals(): INFO - Pedestal file [from ARA_UTIL_INSTALL_DIR/share/calib]");
-                }
+        char calibDir[FILENAME_MAX];
+        char *calibEnv=getenv("ARA_CALIB_DIR");
+        if(!calibEnv) {
+            char *utilEnv=getenv("ARA_UTIL_INSTALL_DIR");
+            if(!utilEnv) {
+                sprintf(calibDir,"calib");
+            } else {
+                sprintf(calibDir,"%s/share/araCalib",utilEnv);
             }
-            else {
-                strncpy(calibDir,calibEnv,FILENAME_MAX);
-                // fprintf(stdout,"AraEventCalibrator::loadAtriPedestals(): INFO - Pedestal file [from ARA_CALIB_DIR]");
-            }
-            sprintf(fAtriPedFile[calibIndex],"%s/ATRI/araAtriStation%iPedestals.txt",calibDir, stationId);
-            // fprintf(stdout," = %s\n",fAtriPedFile[calibIndex]);
-        } // end of IF-block for pedestal file not specified by environment variable
+        }
         else {
-            strncpy(fAtriPedFile[calibIndex],pedFileEnv,FILENAME_MAX);
-            // fprintf(stdout,"AraEventCalibrator::loadAtriPedestals(): INFO - Pedestal file [from ARA_ONE_PEDESTAL_FILE] = %s\n",fAtriPedFile[calibIndex]);
-        } // end of IF-block for pedestal file specified by environment variable
+            strncpy(calibDir,calibEnv,FILENAME_MAX);
+        }
+        sprintf(fAtriPedFile[calibIndex],"%s/ATRI/araAtriStation%iPedestals.txt",calibDir, stationId);
+        char errMsg[500];
+        sprintf(errMsg, "%s -- no pedFile passed! A pedestal file must be passed.", __FUNCTION__);
+        sprintf(errMsg, "%s\n\tIt is best-practice to use a run-specific pedestal file, but ''default'' pedestals are available (use with caution): %s", errMsg, fAtriPedFile[calibIndex]);
+        throw std::runtime_error(errMsg);
     }
     
     // Pedestal file

--- a/AraEvent/AraEventCalibrator.cxx
+++ b/AraEvent/AraEventCalibrator.cxx
@@ -1783,12 +1783,12 @@ void AraEventCalibrator::loadAtriPedestals(AraStationId_t stationId)
     if(fGotAtriPedFile[calibIndex]==1){
         if(!fileExists(fAtriPedFile[calibIndex])){
             char errMsg[500];
-            sprintf(errMsg, "%s -- pedFile does not exist!\n", __FUNCTION__);
+            sprintf(errMsg, "%s -- pedFile %s does not exist!\n", __FUNCTION__, fAtriPedFile[calibIndex]);
             throw std::runtime_error(errMsg);
         }
         else if(numberOfPedestalValsInFile(fAtriPedFile[calibIndex]) != RFCHAN_PER_DDA*DDA_PER_ATRI*BLOCKS_PER_DDA*SAMPLES_PER_BLOCK){
             char errMsg[500];
-            sprintf(errMsg, "%s -- pedFile has too few values!\n", __FUNCTION__);
+            sprintf(errMsg, "%s -- pedFile %s has too few values!\n", __FUNCTION__, fAtriPedFile[calibIndex]);
             throw std::runtime_error(errMsg);
         }
     }

--- a/test/fileAndEventCal.cxx
+++ b/test/fileAndEventCal.cxx
@@ -4,6 +4,7 @@
 
 #include "RawAtriStationEvent.h"
 #include "UsefulAtriStationEvent.h"
+#include "AraEventCalibrator.h"
 
 #include <iostream>
 #include <stdio.h>
@@ -47,6 +48,31 @@ int main(int argc, char **argv){
 		printf("Number of events is %d (%d expected). Test will fail.",numEntries, numEntries_expected);
 		exit(-1);
 	}
+
+  // get stationId
+  eventTree->GetEntry(0);
+  int stationId = rawEvent->stationId;
+
+  // guess where the default pedestal is 
+  char ped_file_name[500];
+  char calibDir[FILENAME_MAX];
+  char *calibEnv=getenv("ARA_CALIB_DIR");
+  if(!calibEnv) {
+      char *utilEnv=getenv("ARA_UTIL_INSTALL_DIR");
+      if(!utilEnv) {
+          sprintf(calibDir,"calib");
+      } else {
+          sprintf(calibDir,"%s/share/araCalib",utilEnv);
+      }
+  }
+  else {
+      strncpy(calibDir,calibEnv,FILENAME_MAX);
+  }
+  sprintf(ped_file_name,"%s/ATRI/araAtriStation%iPedestals.txt",calibDir, stationId);
+  
+  // pass the default pedestal for this test     
+  AraEventCalibrator* calibrator = AraEventCalibrator::Instance();
+  calibrator->setAtriPedFile(ped_file_name, stationId); 
 
 	// make sure that when we get a fully calibrated event, the mean of every waveform is zero
 	for(int event=0; event<numEntries; event++){


### PR DESCRIPTION
Changed behavior to crash if the passed pedestal does not load properly. If no pedestal is passed by the user, the code will crash and give a message suggesting where one might find the default pedestals.

My only concern is whether this might break AWARE.