### PR TITLE
Tune SPT landmark z for surface-like station-centric depth

### DIFF
--- a/AraEvent/AraGeomTool.cxx
+++ b/AraEvent/AraGeomTool.cxx
@@ -54,7 +54,7 @@ Double_t fSouthPole2011_12[3]={27322.88*fFtInm,-3369.89*fFtInm,-36.02*fFtInm};
 // If you know the true SPT depth in ARA global coordinates, please replace the value
 // below and add a reference.
 
-Double_t fSouthPoleTelescope[3]={24774.18*fFtInm,-871.35*fFtInm,0.305}; // z in meters (tuned offset)
+Double_t fSouthPoleTelescope[3]={24774.18*fFtInm,-871.35*fFtInm,1.000656*fFtInm}; // z in meters (tuned offset)
 
 
 Double_t fICL2011_12[4][3]={{24011.58*fFtInm,-1702.53*fFtInm,0},

--- a/AraEvent/AraGeomTool.cxx
+++ b/AraEvent/AraGeomTool.cxx
@@ -44,7 +44,19 @@ const Double_t fAU=149597890000; //(in meters)
 // Some locations in ARA global coordinates
 Double_t fSouthPole2010_11[3]={27344.05*fFtInm,-3395.14*fFtInm,-35.63*fFtInm};
 Double_t fSouthPole2011_12[3]={27322.88*fFtInm,-3369.89*fFtInm,-36.02*fFtInm};
-Double_t fSouthPoleTelescope[3]={24774.18*fFtInm,-871.35*fFtInm,-30*fFtInm};  ///< Made up the u-number
+
+// Paramita Dasgupta (PDG): SouthPoleTelescope (SPT) is a surface landmark (array z≈0), but after converting from ARA global
+// (array) coordinates to station-centric coordinates, the station rotation can mix x/y into z. As a result,
+// different surface landmarks can end up with slightly different station-centric z values.
+// We therefore apply a small +array-z offset for SPT so that its station-centric z is small and positive,
+// comparable to ICL
+// Date: 1 April 2026.
+// If you know the true SPT depth in ARA global coordinates, please replace the value
+// below and add a reference.
+
+Double_t fSouthPoleTelescope[3]={24774.18*fFtInm,-871.35*fFtInm,0.305}; // z in meters (tuned offset)
+
+
 Double_t fICL2011_12[4][3]={{24011.58*fFtInm,-1702.53*fFtInm,0},
                             {24060.51*fFtInm,-1723.09*fFtInm,0},
                             {24049.7*fFtInm,-1749.02*fFtInm,0},


### PR DESCRIPTION
This PR updates the South Pole Telescope (SPT) landmark position in `AraGeomTool.cxx`, replacing the previous placeholder depth (-30 ft) with a small tuned +z offset (0.305 m).

Although SPT is a surface landmark (array/global z ≈ 0), converting from **ARA global coordinates** to **station-centric coordinates** applies a station rotation that can mix `x/y` into `z`. The value **0.305 m** was therefore chosen empirically so that, after `convertArrayToStationCoords()`, SPT’s `station-centric z` is **small and positive** and close to the IceCube Lab (ICL) station-centric z, improving consistency for landmark ray-tracing / map marker placement.

To see the effect : After this update, AraRoot was rebuilt and skymap re-plotted to validate the change. See attached skymap which shows SPT now appearing at the expected (surface-like) elevation in the station-centric coordinate system.



**Plots post-SPT depth corrections** 
[station_5_run_6203_eventNo_784_map_distant_v_dir.pdf](https://github.com/user-attachments/files/26427868/station_5_run_6203_eventNo_784_map_distant_v_dir.pdf)
[station_2_run_3902_eventNo_950_map_distant_v_dir.pdf](https://github.com/user-attachments/files/26442166/station_2_run_3902_eventNo_950_map_distant_v_dir.pdf)
[station_3_run_3902_eventNo_950_map_distant_v_dir.pdf](https://github.com/user-attachments/files/26442167/station_3_run_3902_eventNo_950_map_distant_v_dir.pdf)
[station_4_run_3902_eventNo_1150_map_distant_v_dir.pdf](https://github.com/user-attachments/files/26442168/station_4_run_3902_eventNo_1150_map_distant_v_dir.pdf)
[station_100_run_3902_eventNo_950_map_distant_v_dir.pdf](https://github.com/user-attachments/files/26442169/station_100_run_3902_eventNo_950_map_distant_v_dir.pdf)


Here is the coordinate that went into AraSim Ray-tracer 
```
S5 : 
name   =  ICL
 source_xyz   =  [ 4.85383145e+02 -5.70186146e+03  7.55984245e-02]
name   =  SPT
 source_xyz   =  [ 5.49164908e+02 -6.03971285e+03  5.44097150e-02]

S4 : 
 name   =  ICL
 source_xyz   =  [-3140.15221446 -1824.87808405     4.63444946]
  name   =  SPT
 source_xyz   =  [-3076.37061149 -2162.72944044     4.85797051]

S3: 
name   =  ICL
 source_xyz   =  [-2.30778907e+03 -3.66461022e+03  2.83449979e-01]


 name   =  SPT
 source_xyz   =  [-2.24400741e+03 -4.00246162e+03  4.01594861e-01]

S2: 

name   =  ICL
 source_xyz   =  [-3.20952781e+02 -3.90202801e+03  2.95687116e+00]
name   =  SPT
 source_xyz   =  [-2.57171047e+02 -4.23987941e+03  3.04269382e+00]

S100: 
 name   =  ICL
 source_xyz   =  [-1111.97696697 -2064.65030107     6.62087364]

name   =  SPT
 source_xyz   =  [-1048.19527481 -2402.50166077     6.81153638]
```
